### PR TITLE
Fix issue #52

### DIFF
--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -48,8 +48,8 @@ function url2path(url) {
             var unixPath = uri.path;
 
             // hack to have ~ path working in Linux
-            unixPath = unixPath.replace(/(\/){1,2}~/, "~"); // one or two slashes before ~
-
+            unixPath = unixPath.replace(/(\/){1,2}~(\/)/, "~/"); // one or two slashes before ~ // stop at first / after ~
+            
             file.initWithPath(unixPath);
           } catch (e) {}
           try { // Windows sucks

--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -48,7 +48,7 @@ function url2path(url) {
             var unixPath = uri.path;
 
             // hack to have ~ path working in Linux
-            unixPath = unixPath.replace(/(\/){1,2}~(\/)/, "~/"); // one or two slashes before ~ // stop at first / after ~
+            unixPath = unixPath.replace(/(\/){1,2}~\//, "~/"); // one or two slashes before ~ // stop at first / after ~
             
             file.initWithPath(unixPath);
           } catch (e) {}

--- a/test/webserver/std1/issue.htm
+++ b/test/webserver/std1/issue.htm
@@ -3,7 +3,10 @@
 <body>
 <ul>
     <li>
-        <a href="file:///C:/tmp/existing_file - Kopie.txt">C:/tmp/existing_file - Kopie.txt</a>
+        <a href="file:///C:/tmp/existing_file - Kopie.txt">C:/tmp/existing_file - Kopie.txt (tripple slash - style file:///)</a>
+    </li>
+    <li>
+        <a href="file://C:/tmp/existing_file - Kopie.txt">C:/tmp/existing_file - Kopie.txt (double slash - style file://)</a>
     </li>
     <li>
         <a href="file:///C:/tmp/existing_file.txt">C:/tmp/existing_file.txt</a>
@@ -43,6 +46,12 @@
     </li>
     <li>
         Linux: <a href="file:///~/dev">file:///~/dev</a> (works if path exists)
+    </li>
+     <li>
+        Linux: <a href="file:///tmp/company/~Office/file.txt">file:///tmp/company/~Office/file.txt</a> (Symbol ~ allowed in path)
+    </li>
+    <li>
+        Linux: <a href="file:///tmp/company/~Office/~file.txt">file:///tmp/company/~Office/~file.txt</a> (Symbol ~ allowed in filename)
     </li>
     <li>
         Linux: <a href="smb://diskstationwolf/photo/">smb://diskstationwolf/photo</a> (not working yet.)


### PR DESCRIPTION
Doesn't affect the other "~ links" and allows ~ symbol in path and filename.

I've changed the regex to match the first occuerence of ~ to prepare the path for opening and ignore the other ~ symbols in the link.