### PR TITLE
Improve issue 32

### DIFF
--- a/data/css/style.css
+++ b/data/css/style.css
@@ -6,7 +6,6 @@
 .aliensun-link-icon a {
     display: table-cell;
     text-decoration: none;
-    /*padding-top: 0.4em;*/
 }
 
 .aliensun-link-icon i{
@@ -23,42 +22,3 @@
 .aliensun-link-icon i:hover:after{
     content: "folder_open";
 }
-
-/*remove css tooltip --> just a html title is OK */
-/*
-.aliensun-link-icon a {
-      position: relative;
-      font-family: Sans-Serif;
-}
-
-.aliensun-link-icon  a[data-tooltip]:before {
-    position: absolute;
-    left: 2.5em;
-    top: 0em;
-    height: 1.5em;
-    color: black;
-    background-color: lightgray;
-    padding: 10% 0 10% 0;
-    content: attr(data-tooltip);
-    font-size: 0.5em;
-    white-space: nowrap;
-    display: none;
-    border-radius: 0.2em;
-}
-
-.aliensun-link-icon  a[data-tooltip]:after {
-    position: absolute;
-    left: 1.1em;
-    top: 0.175em;
-    border-right: 0.2em solid lightgray;
-    border-top: 0.2em solid transparent;
-    border-bottom: 0.2em solid transparent;
-    content: "";
-    display: none;
-}
-
-.aliensun-link-icon a[data-tooltip]:hover:after,
-.aliensun-link-icon a[data-tooltip]:hover:before {
-    display: block;
-}
-*/

--- a/data/css/style.css
+++ b/data/css/style.css
@@ -1,15 +1,57 @@
 .aliensun-link-icon {
+    display: inline-block;
+}
+
+.aliensun-link-icon i {
     /*padding-left: 2px;*/
     color: orange; /*#F3C300;*/
     font-size: 100% !important;
     text-shadow: 0.1em 0.1em 0.1em rgba(150, 150, 150, 1);
+    cursor: pointer;
 }
 
-.aliensun-link-icon:after {
+.aliensun-link-icon i:after {
     content: "folder";
     font-size: 100% !important;
 }
 
-a:hover .aliensun-link-icon:after{
+/*.aliensun-link-icon */
+.aliensun-link-icon a:hover > i:after{
     content: "folder_open";
+}
+
+
+.aliensun-link-icon a {
+      position: relative;
+}
+
+/*.aliensun-link-icon > */
+.aliensun-link-icon  a[data-tooltip]:before {
+    position: absolute;
+    left: 1.5em;
+    top: -0.25em;
+    color: black;
+    background-color: lightgray;
+    padding: 0.2em;
+    content: attr(data-tooltip);
+    white-space: nowrap;
+    display: none;
+    border-radius: 0.2em;
+}
+
+/*.aliensun-link-icon > */
+.aliensun-link-icon  a[data-tooltip]:after {
+    position: absolute;
+    left: 1.25em;
+    top: 0.3em;
+    border-right: 0.3em solid lightgray;
+    border-top: 0.3em solid transparent;
+    border-bottom: 0.3em solid transparent;
+    content: "";
+    display: none;
+}
+
+.aliensun-link-icon a[data-tooltip]:hover:after,
+.aliensun-link-icon a[data-tooltip]:hover:before {
+    display: block;
 }

--- a/data/css/style.css
+++ b/data/css/style.css
@@ -13,6 +13,7 @@
     font-size: 100%;
     text-shadow: 0.1em 0.1em 0.1em rgba(150, 150, 150, 1);
     vertical-align: -0.2em; /* correction of y-position of icon */
+    cursor: pointer;
 }
 
 .aliensun-link-icon i:after {

--- a/data/css/style.css
+++ b/data/css/style.css
@@ -1,52 +1,58 @@
 .aliensun-link-icon {
-    display: inline-block;
+    display: inline-table;
+    padding-left: 0.1em;
 }
 
-.aliensun-link-icon i {
-    /*padding-left: 2px;*/
+.aliensun-link-icon a {
+    display: table-cell;
+    text-decoration: none;
+    /*padding-top: 0.4em;*/
+}
+
+.aliensun-link-icon i{
     color: orange; /*#F3C300;*/
-    font-size: 100% !important;
+    font-size: 100%;
     text-shadow: 0.1em 0.1em 0.1em rgba(150, 150, 150, 1);
-    cursor: pointer;
+    vertical-align: -0.2em; /* correction of y-position of icon */
 }
 
 .aliensun-link-icon i:after {
     content: "folder";
-    font-size: 100% !important;
 }
 
-/*.aliensun-link-icon */
-.aliensun-link-icon a:hover > i:after{
+.aliensun-link-icon i:hover:after{
     content: "folder_open";
 }
 
-
+/*remove css tooltip --> just a html title is OK */
+/*
 .aliensun-link-icon a {
       position: relative;
+      font-family: Sans-Serif;
 }
 
-/*.aliensun-link-icon > */
 .aliensun-link-icon  a[data-tooltip]:before {
     position: absolute;
-    left: 1.5em;
-    top: -0.25em;
+    left: 2.5em;
+    top: 0em;
+    height: 1.5em;
     color: black;
     background-color: lightgray;
-    padding: 0.2em;
+    padding: 10% 0 10% 0;
     content: attr(data-tooltip);
+    font-size: 0.5em;
     white-space: nowrap;
     display: none;
     border-radius: 0.2em;
 }
 
-/*.aliensun-link-icon > */
 .aliensun-link-icon  a[data-tooltip]:after {
     position: absolute;
-    left: 1.25em;
-    top: 0.3em;
-    border-right: 0.3em solid lightgray;
-    border-top: 0.3em solid transparent;
-    border-bottom: 0.3em solid transparent;
+    left: 1.1em;
+    top: 0.175em;
+    border-right: 0.2em solid lightgray;
+    border-top: 0.2em solid transparent;
+    border-bottom: 0.2em solid transparent;
     content: "";
     display: none;
 }
@@ -55,3 +61,4 @@
 .aliensun-link-icon a[data-tooltip]:hover:before {
     display: block;
 }
+*/

--- a/data/js/fileLinkAddonContent.js
+++ b/data/js/fileLinkAddonContent.js
@@ -9,17 +9,17 @@
             /*'a[href^="smb://"]',
             'a[href^="afp://"]'*/
         ],
-        $container = $('<div class="aliensun-link-icon"/>'),
-        $icon = $container.append($('<a href="#"/>')
-                        .attr("data-tooltip", "Open folder")
-                        .append($( "<i/>" )
-                            .addClass( "material-icons" ))
-                    ),
-        options = {
-            enableLinkIcons: self.options.enableLinkIcons
+        appTextMessages = {
+            // every constant text we're showing the user
+            // e.g. tooltip text constants
         },
-        tooltipFilemanagerText,
-        appName,
+        $container = $('<span class="aliensun-link-icon"/>'),
+        $icon = {}, // loading, see init
+        options = {
+            //enableLinkIcons: self.options.enableLinkIcons
+        },
+        tooltipFilemanagerText, // not used yet?
+        appName,            // where is it used?
         latestNodesAdded;
     /**
      * Activates the plugin - add icon after link and starts observer if enabled
@@ -30,25 +30,39 @@
             createObserver();
             updateLink($(fileLinkSelectors.join(', ')));
         }
+
+        // we could add a if case here to add tooltip disable pref.
+        $('a').filter(fileLinkSelectors.join(', '))
+            .attr('title', appTextMessages.tooltips.linkText);
     }
 
     // Get settings from addon
-    self.port.on( "initSettings", function( data ) {
-        // console.log('init', data);
-        options.enableLinkIcons = data.enableLinkIcons;
-        activate();
-    } );
+    self.port.on( "init", function( addonOptions, constants) {
+        // console.log('init', addonOptions, constants);
+        // load plugin options
+        options = addonOptions;
 
-    // Get message texts from addon
-    self.port.on( "textConstants", function( constants ) {
+        // load constant texts from addon
         tooltipFilemanagerText = constants.MESSAGES.FILEMANAGER;
         appName = constants.APP.name;
+        appTextMessages = constants.MESSAGES.USERMESSAGES;
+        // console.log('test', appTextMessages);
+        $icon = $container.append($( "<i/>" )
+                            .attr("title",
+                                appTextMessages.tooltips.openFolder)
+                            .addClass( "material-icons" )
+                    );
+
+        // now everything is ready to load
+        activate();
     } );
 
     // Update settings on change of pref.
     self.port.on( "prefLinkIconChange", function( data ) {
-        options.enableLinkIcons = data.enableLinkIcons;
-        // console.log('pref changed');
+        // options.enableLinkIcons = data.enableLinkIcons;
+        options = $.extend({}, options, data);
+
+        // console.log('pref changed', data, options);
         if ( !options.enableLinkIcons ) {
             removeLinkIcons();
         } else {
@@ -66,11 +80,26 @@
         } );
     } );
 
+    /*
+      Event for icon to reveal the folder directly
+    */
+    function openFolderHandler(e) {
+        var link = $(e.currentTarget).data('link');
+        e.preventDefault();
+
+        // we need to check if file has 2 slashes because ff won't fix it here
+        link = link.replace(/file:[\/]{2,3}/i, 'file:\/\/\/');
+        // console.log('clicked icon', link);
+        // alert('clicked icon');
+        self.postMessage( {
+            action: "reveal",
+            // url: decodeURIComponent( $(e.currentTarget).data('link'))
+            url: decodeURIComponent(link)
+        } );
+    }
+
     // icon click handler
-    $( document ).on( "click", ".aliensun-link-icon>a", function( e ) {
-        //e.preventDefault();
-        console.log('hello', e);
-    });
+    $( document ).on( "click", ".aliensun-link-icon", openFolderHandler);
 
     // -------------------------------------------------------------------------
     // add link icons (if enabled)
@@ -95,8 +124,19 @@
     // --> final solution: use jquery-observe that's simplyfing mutationObserver
 
     function updateLink($element) {
-        //console.log('updating', $element);
-        $icon.clone().insertAfter($element);
+        // console.log('updating', $element);
+        $element.each(function(index, el) {
+            // console.log('el href = ', $(el).attr('href'));
+            $icon
+                .clone()
+                .data('link', $(el).attr('href')) // added to container
+                // .click(openFolderHandler)
+                .insertAfter($(el));
+        });
+        // $icon
+        //     .clone()
+        //     .data('link', $element.attr('href')) // added to container
+        //     .insertAfter($element);
     }
 
     /**
@@ -104,9 +144,7 @@
       * (needed for updating at icon pref. change)
       */
     function removeLinkIcons() {
-        var $icons = $('i')
-            .filter('.' +
-                $icon.attr('class').split(' ').join('.'));
+        var $icons = $('.aliensun-link-icon');
         // console.log('test',$icons);
 
         $icons.remove();

--- a/data/js/fileLinkAddonContent.js
+++ b/data/js/fileLinkAddonContent.js
@@ -9,8 +9,12 @@
             /*'a[href^="smb://"]',
             'a[href^="afp://"]'*/
         ],
-        $icon = $( "<i/>" )
-                    .addClass( "material-icons aliensun-link-icon" ),
+        $container = $('<div class="aliensun-link-icon"/>'),
+        $icon = $container.append($('<a href="#"/>')
+                        .attr("data-tooltip", "Open folder")
+                        .append($( "<i/>" )
+                            .addClass( "material-icons" ))
+                    ),
         options = {
             enableLinkIcons: self.options.enableLinkIcons
         },
@@ -62,6 +66,11 @@
         } );
     } );
 
+    // icon click handler
+    $( document ).on( "click", ".aliensun-link-icon>a", function( e ) {
+        //e.preventDefault();
+        console.log('hello', e);
+    });
 
     // -------------------------------------------------------------------------
     // add link icons (if enabled)
@@ -87,7 +96,7 @@
 
     function updateLink($element) {
         //console.log('updating', $element);
-        $icon.clone().appendTo($element);
+        $icon.clone().insertAfter($element);
     }
 
     /**

--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -12,5 +12,11 @@ exports.MESSAGES = {
     ERROR: {
         BAD_LINK: "Couldn't open file: "
     },
-    FILEMANAGER: osFileManagerName()
+    FILEMANAGER: osFileManagerName(),
+    USERMESSAGES: {
+        tooltips: {
+            openFolder: 'Open folder',
+            linkText: 'Open link'
+        }
+    }
 };

--- a/lib/contextMenu.js
+++ b/lib/contextMenu.js
@@ -1,17 +1,18 @@
 // ContextMenu.js
 
-// Creates a menu item to do the following:
+// Creates a context menus to do the following:
 // - execute the link with reveal mode instead of opening file
 // - execute selected file link
+// (two cases selected text and right click on link --> two menus)
 
 var contextMenu = require( "sdk/context-menu" );
 
 /**
- * Creates two context menu items for different use cases:
- * 1. if user selected a link text file://... the menuItemSelect will be in the context menu
- * 2. if the user right clicks at a file link he can reveal the directory of a file link.
+ * Creates two context submenus for different use cases (with open and reveal):
+ * 1. if user selected a link text file://...
+ * 2. if the user right clicks at a file link
  *
- * @param callback(path, reaveal) reveal = true --> reveals folder
+ * @param callback(path, reveal) reveal = true --> reveals folder
  */
 module.exports = function( callback ) {
     var selectContentScript = 'self.on("click", function () {' +
@@ -20,8 +21,7 @@ module.exports = function( callback ) {
         "});"; // Could be refactored to a separate file later --> improve readability
 
     var menuItemSelect = contextMenu.Item( {
-        label: "Link addon - execute selected link",
-        context: contextMenu.SelectionContext(),
+        label: "Open link",
         contentScript: selectContentScript,
 
         //AccessKey: "l",
@@ -31,8 +31,7 @@ module.exports = function( callback ) {
     } );
 
     var menuItemSelectReveal = contextMenu.Item( {
-        label: "Link addon - execute selected link (reveal)",
-        context: contextMenu.SelectionContext(),
+        label: "Open containing folder",
         contentScript: selectContentScript,
 
         //AccessKey: "l",
@@ -41,12 +40,13 @@ module.exports = function( callback ) {
         }
     } );
 
-    var menuItemOptions = contextMenu.Item( {
-        label: "Link addon - reveal selected link",
-        context: contextMenu.SelectorContext( "a[href]" ),
-        contentScript: 'self.on("click", function (node , data) {' +
-            "  self.postMessage(node.href);" +
-            "});",
+    var itemContentScript = 'self.on("click", function (node , data) {' +
+        "  self.postMessage(node.href);" +
+        "});";
+
+    var menuItemFolder = contextMenu.Item( {
+        label: "Open containing folder",
+        contentScript: itemContentScript,
 
         //AccessKey: "l",
         onMessage: function( url ) {
@@ -55,4 +55,36 @@ module.exports = function( callback ) {
             callback( url, true );
         }
     } );
+
+    var menuItemLink = contextMenu.Item( {
+        label: "Open link",
+        contentScript: itemContentScript,
+
+        //AccessKey: "l",
+        onMessage: function( url ) {
+
+            //Console.log(url);
+            callback( url, false );
+        }
+    } );
+
+    // create a submenu for selection
+    var subMenuSelection = contextMenu.Menu({
+        label: 'Link addon selection',
+        context: contextMenu.SelectionContext(),
+        items: [
+            menuItemSelect,
+            menuItemSelectReveal
+        ]
+    });
+
+    // create a submenu for right click on link
+    var subMenuRightClick = contextMenu.Menu({
+        label: 'Link addon',
+        context: contextMenu.SelectorContext( "a[href]" ),
+        items: [
+            menuItemLink,
+            menuItemFolder
+        ]
+    });
 };

--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -49,10 +49,11 @@ function url2path(url) {
 
             // hack to have ~ path working in Linux
             unixPath = unixPath.replace(/(\/){1,2}~\//, "~/"); // one or two slashes before ~ // stop at first / after ~
-            
+
             file.initWithPath(unixPath);
           } catch (e) {}
           try { // Windows sucks
+            //   console.log('windows', uri.path, path);
             file.initWithPath(uri.path.replace(/^\//,"").replace(/\//g,"\\"));
           } catch (e) {}
           path = decodeURI(file.path);
@@ -80,7 +81,7 @@ function getNsIFileFromPath ( path ) {
     // (but Windows explorer would be)
 
     localPath = url2path(localPath); //linkUtil.osSpecificLinkStringFix( localPath );
-    //console.log('localpath', localPath);
+    // console.log('localpath', localPath);
 
     // the following code works except smb/afp
 
@@ -108,22 +109,28 @@ function pathExists( localFile ) {
 exports.pathExists = pathExists;
 
 function start( path, reveal ) {
-
+    // if reveal omit the file so we're getting the folder even with a
+    // non-existing file
+    // console.log('remove file if reveal', reveal? (/^(.*\/)([^/]*)$/).exec(path)[1] : 'no reveal');
+    path = reveal ? (/^(.*\/)([^/]*)$/).exec(path)[1]: path;
     var nsLocalFile = getNsIFileFromPath( path );
 
+
     if ( pathExists( nsLocalFile ) ) {
+        // console.log('path exists', nsLocalFile);
         if ( reveal ) {
             nsLocalFile.reveal();
         } else {
-                nsLocalFile.launch();
+            nsLocalFile.launch();
         }
     } else {
+        // console.log("path doesn't exist", path, reveal);
         if ( openSmbLink ) { // add os-check later
             // check configuration and modify it if necessary.
             // better check the settings on pageMod attach
             notification.show( CONST.APP.name, 'Configuration changed! SMB links now enabled');
         } else {
-            notification.show( CONST.APP.name, CONST.MESSAGES.ERROR.BAD_LINK + path );
+            notification.show( CONST.APP.name, CONST.MESSAGES.ERROR.BAD_LINK + decodeURI(path) );
         }
     }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -44,18 +44,19 @@ function onAttach( worker ) {
 
         switch ( actionObj.action ) {
 
-            // Actions not really needed for one task but during develeopment I had more
-            // tasks --> maybe remove it later
+            // Actions from content-script
             case "open":
                 launcher.start( actionObj.url );
+            break;
+
+            case "reveal":
+                launcher.start( actionObj.url, true);
             break;
         }
 
     } );
 
-    worker.port.emit( "initSettings", prefs.options );
-
-    worker.port.emit( "textConstants", CONST );
+    worker.port.emit( "init", prefs.options, CONST );
 
     // Pageshow / pagehide not needed but we could remove workers if page is hidden
     // could be useful for context menus. --> not needed here
@@ -72,7 +73,7 @@ function onAttach( worker ) {
         var newEmitObj = {};
         newEmitObj[ prefName ] = prefs.options[ prefName ];
 
-        console.log('pref link change', newEmitObj, prefName);
+        // console.log('pref link change', newEmitObj, prefName);
         worker.port.emit( "prefLinkIconChange", newEmitObj );
     }
 

--- a/test/webserver/issue2/issue.htm
+++ b/test/webserver/issue2/issue.htm
@@ -9,10 +9,10 @@
         <a href="file:///C:/tmp/path with blanks non ex">C:/tmp/path with blanks that does not exist</a>
     </li>
     <li>
-        C:/tmp/path with blanks <small>(select, right click, Open with 'File Manager')</small>
+        file:///C:/tmp/path with blanks <small>(select, right click, Open with 'File Manager')</small>
     </li>
     <li>
-        C:/tmp/path with blanks moo <small>(select, right click, Open with 'File Manager')</small>
+        file:///C:/tmp/path with blanks moo <small>(select, right click, Open with 'File Manager')</small>
     </li>
 </ul>
 </body>

--- a/test/webserver/issue53/index.html
+++ b/test/webserver/issue53/index.html
@@ -8,10 +8,6 @@
                 display: inline;
             }
 
-            .links :after {
-                content: '\A';
-                white-space: pre;
-            }
             .small {
                 font-size: 9px;
             }
@@ -28,11 +24,11 @@
     </head>
     <body>
         <h1>Add everything style related here (e.g. icon size)</h1>
-        <p class="links">
-            <a href="file://c:/" class="small">c:\ link small</a>
-            <a href="file://c:/" class="medium">c:\ link medium</a>
-            <a href="file://c:/" class="normal">c:\ link normal</a>
-            <a href="file://c:/" class="large">c:\ link large</a>
+        <ul class="links">
+            <li><a href="file://c:/" class="small">c:\ link small</a></li>
+            <li><a href="file://c:/" class="medium">c:\ link medium</a></li>
+            <li><a href="file://c:/" class="normal">c:\ link normal</a></li>
+            <li><a href="file://c:/" class="large">c:\ link large</a></li>
         </p>
     </body>
 </html>

--- a/test/webserver/issue53/index.html
+++ b/test/webserver/issue53/index.html
@@ -4,10 +4,6 @@
         <meta charset="utf-8">
         <title>Issue 53 - Style improvement</title>
         <style>
-            .links {
-                display: inline;
-            }
-
             .small {
                 font-size: 9px;
             }
@@ -24,11 +20,11 @@
     </head>
     <body>
         <h1>Add everything style related here (e.g. icon size)</h1>
-        <ul class="links">
-            <li><a href="file://c:/" class="small">c:\ link small</a></li>
-            <li><a href="file://c:/" class="medium">c:\ link medium</a></li>
-            <li><a href="file://c:/" class="normal">c:\ link normal</a></li>
-            <li><a href="file://c:/" class="large">c:\ link large</a></li>
+        <ul>
+            <li class="small"><a href="file://c:/">c:\ link small</a>Some text here</li>
+            <li class="medium"><a href="file://c:/">c:\ link medium</a>some text....</li>
+            <li class="normal"><a href="file://c:/">c:\ link normal</a>Some text here</li>
+            <li class="large"><a href="file://c:/">c:\ link large</a>some text....</li>
         </p>
     </body>
 </html>

--- a/test/webserver/std1/issue.htm
+++ b/test/webserver/std1/issue.htm
@@ -9,6 +9,12 @@
         <a href="file://C:/tmp/existing_file - Kopie.txt">C:/tmp/existing_file - Kopie.txt (double slash - style file://)</a>
     </li>
     <li>
+        <a href="file://C:/">C:/ (double slash - style file:// - reveal issue - fixed)</a>
+    </li>
+    <li>
+        <a href="file:///C:/">C:/ (tripple slash - style file:/// - reveal working)</a>
+    </li>
+    <li>
         <a href="file:///C:/tmp/existing_file.txt">C:/tmp/existing_file.txt</a>
     </li>
     <li>


### PR DESCRIPTION
I think my improvement is ready and can be merged to master.

You can look at issue #32 for an screenshot of the icon with tooltip in action. At the icon style I've only optimised the vertical position a little bit so it's better centered now.

The reveal action needed me to modify the passed link because reveal failed with a two slash link style. So I've fixed the link before passing it to the addon. This seems a bit hacky but it is working. (It won't break anything, I've tested Linux & Windows)

I've also improved the reveal action because before opening the containing folder of a non-existing file wasn't working. No I'm removing the file before the action and it works.

The context menu is improved too. I've group it into two submenus depending on the action. One for right click with selected text and the other with right click on a link-tag.
