### PR TITLE
Sec. improve issue 16 (disable executables with preference)

### DIFF
--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -127,16 +127,19 @@ exports.pathExists = pathExists;
 
 function start( path, reveal ) {
     var fileRegex = /^(.*\/)([^\/]*)$/,
+        allowAll = prefs.options.enableExecutables;
+    /*,
         match = fileRegex.exec(path),
         isExecutable = isWindowsOs() ?
             /(\.exe|\.bat|\.bin|\.cmd|\.com|\.ms[ipt])$/i.test(path) : 
             /^(.*\/bin\/.*)$/i.test(path),
         fileDir = match[1],
         fileName = match[2],
-        allowAll = prefs.options.enableExecutables;
+        allowAll = prefs.options.enableExecutables;*/
 
     //console.log('check if exe', isExecutable, fileName, fileDir);
 
+    /*
     if ( !reveal && isExecutable ) {
         // no reveal = direct file link to an executable file
         // check if exe is enabled
@@ -149,7 +152,7 @@ function start( path, reveal ) {
                 "You're trying to open an executable file. Please check addon settings to enable executable files and try again." );
             return false;
         } //else we can execute the rest of the start code
-    }
+    }*/
     // console.log('remove file if reveal', path, reveal? (/^(.*\/)([^/]*)$/).exec(path)[1] : 'no reveal');
 
 
@@ -190,7 +193,12 @@ function start( path, reveal ) {
         if ( reveal ) {
             nsLocalFile.reveal();
         } else {
-            nsLocalFile.launch();
+            if ( nsLocalFile.isExecutable() && !allowAll ) {
+                notification.show( CONST.APP.name,
+                    "You're trying to open an executable file. Please check addon settings to enable executable files and try again." );
+            } else {
+                nsLocalFile.launch();
+            }
         }
     } else {
         // console.log("path doesn't exist", path, reveal);

--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -128,21 +128,25 @@ exports.pathExists = pathExists;
 function start( path, reveal ) {
     var fileRegex = /^(.*\/)([^\/]*)$/,
         match = fileRegex.exec(path),
-        isExecutable = isWindowsOs ?
-            /(\.exe)$/i.test(path) : /^(.*\/bin\/.*)$/i.test(path),
+        isExecutable = isWindowsOs() ?
+            /(\.exe|\.bat|\.bin|\.cmd|\.com|\.ms[ipt])$/i.test(path) : 
+            /^(.*\/bin\/.*)$/i.test(path),
         fileDir = match[1],
         fileName = match[2],
-        whiteListExe = prefs.options.whitelistExecutables.split(/\s+/),
-        allowAll = ( whiteListExe.indexOf('*') !== -1 );
+        allowAll = prefs.options.enableExecutables;
 
-    console.log('check if exe', isExecutable, fileName, fileDir, whiteListExe);
+    //console.log('check if exe', isExecutable, fileName, fileDir);
 
     if ( !reveal && isExecutable ) {
         // no reveal = direct file link to an executable file
-        // check exe whitelist
-        if (whiteListExe.indexOf(fileName) === -1 && !allowAll ) {
+        // check if exe is enabled
+        // info windows should work for most critical file extensions
+        // info linux test seems a bit week as it only tests if the link contains /bin
+        //      are there other critical folders except /usr/bin?
+        
+        if (!allowAll ) {
             notification.show( CONST.APP.name,
-                "You're trying to open a not whitelisted executable file. Please check addon settings and try again." );
+                "You're trying to open an executable file. Please check addon settings to enable executable files and try again." );
             return false;
         } //else we can execute the rest of the start code
     }

--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -3,6 +3,8 @@ var { Cc, Ci, Cu } = require( "chrome" ), // Use Components.classes & Components
     linkUtil = require( "./utils/link-util" ),
     notification = require( "./notification" ),
     CONST = require( "./common/constants" ),
+    prefs = require( "./common/preferences"),
+    {isWindowsOs} = require( "./utils/os-util"),
 
     FileUtils = Cu.import("resource://gre/modules/FileUtils.jsm").FileUtils,
     openSmbLink = false; // true if we have a smb link to open
@@ -124,6 +126,26 @@ function pathExists( localFile ) {
 exports.pathExists = pathExists;
 
 function start( path, reveal ) {
+    var fileRegex = /^(.*\/)([^\/]*)$/,
+        match = fileRegex.exec(path),
+        isExecutable = isWindowsOs ?
+            /(\.exe)$/i.test(path) : /^(.*\/bin\/.*)$/i.test(path),
+        fileDir = match[1],
+        fileName = match[2],
+        whiteListExe = prefs.options.whitelistExecutables.split(/\s+/),
+        allowAll = ( whiteListExe.indexOf('*') !== -1 );
+
+    console.log('check if exe', isExecutable, fileName, fileDir, whiteListExe);
+
+    if ( !reveal && isExecutable ) {
+        // no reveal = direct file link to an executable file
+        // check exe whitelist
+        if (whiteListExe.indexOf(fileName) === -1 && !allowAll ) {
+            notification.show( CONST.APP.name,
+                "You're trying to open a not whitelisted executable file. Please check addon settings and try again." );
+            return false;
+        } //else we can execute the rest of the start code
+    }
     // console.log('remove file if reveal', path, reveal? (/^(.*\/)([^/]*)$/).exec(path)[1] : 'no reveal');
 
 
@@ -148,7 +170,7 @@ function start( path, reveal ) {
 
         // if reveal omit the file so we're getting the folder even with a
         // non-existing file
-        path = (/^(.*\/)([^\/]*)$/).exec(path)[1]; // strip file
+        path = fileRegex.exec(path)[1]; // strip file
 
         if ( ! /file:/i.test(path) ) {
             // selected a link with-out file:// for reveal

--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -128,34 +128,7 @@ exports.pathExists = pathExists;
 function start( path, reveal ) {
     var fileRegex = /^(.*\/)([^\/]*)$/,
         allowAll = prefs.options.enableExecutables;
-    /*,
-        match = fileRegex.exec(path),
-        isExecutable = isWindowsOs() ?
-            /(\.exe|\.bat|\.bin|\.cmd|\.com|\.ms[ipt])$/i.test(path) : 
-            /^(.*\/bin\/.*)$/i.test(path),
-        fileDir = match[1],
-        fileName = match[2],
-        allowAll = prefs.options.enableExecutables;*/
-
-    //console.log('check if exe', isExecutable, fileName, fileDir);
-
-    /*
-    if ( !reveal && isExecutable ) {
-        // no reveal = direct file link to an executable file
-        // check if exe is enabled
-        // info windows should work for most critical file extensions
-        // info linux test seems a bit week as it only tests if the link contains /bin
-        //      are there other critical folders except /usr/bin?
         
-        if (!allowAll ) {
-            notification.show( CONST.APP.name,
-                "You're trying to open an executable file. Please check addon settings to enable executable files and try again." );
-            return false;
-        } //else we can execute the rest of the start code
-    }*/
-    // console.log('remove file if reveal', path, reveal? (/^(.*\/)([^/]*)$/).exec(path)[1] : 'no reveal');
-
-
     //console.log('test if backslash in path', /\\/.test(path), path);
     //if ( /\\/.test(path) ) {
     // test not working because FF converts \ to /

--- a/package.json
+++ b/package.json
@@ -27,10 +27,18 @@
       "value": "*"
     },
     {
+      "name": "whitelistExecutables",
+      "title": "Add executable files that are allowed for opening",
+      "description": "Any progam file you add to this whitelist (space separated) are enabled for opening by the addon (empty means all executables blocked, add * to allow all executables)",
+      "type": "string",
+      "value": ""
+    },
+    {
       "name": "enableLinkIcons",
       "title": "Enable link icons",
       "description": "if checked there will be a link added to every local link",
       "type": "bool",
       "value": true
-    }]
+    }
+]
 }

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
       "value": "*"
     },
     {
-      "name": "whitelistExecutables",
-      "title": "Add executable files that are allowed for opening",
-      "description": "Any progam file you add to this whitelist (space separated) are enabled for opening by the addon (empty means all executables blocked, add * to allow all executables)",
-      "type": "string",
-      "value": ""
+      "name": "enableExecutables",
+      "title": "Enable links to local executable files",
+      "description": "if enabled any progam file can be launched by the addon. (Attention! A malicious site could use this for denial-of-service attack!)",
+      "type": "bool",
+      "value": false
     },
     {
       "name": "enableLinkIcons",

--- a/test/webserver/index.htm
+++ b/test/webserver/index.htm
@@ -26,5 +26,8 @@ it does not if the page is served by a webserver; thats what the add-on is for).
 
 <p><a href="issue53/index.html">Issue 53 - style improvement</a>
     (<a href="https://github.com/feinstaub/firefox_addon_local_filesystem_links/issues/53">Issue 53</a>)</p>
+
+<p><a href="issue16/index.html">Issue 16 - security improvement</a>
+    (<a href="https://github.com/feinstaub/firefox_addon_local_filesystem_links/issues/16">Issue 16</a>)</p>
 </body>
 </html>

--- a/test/webserver/issue16/index.html
+++ b/test/webserver/issue16/index.html
@@ -21,6 +21,8 @@
         <a href="file://C:/Program Files (x86)/Windows NT/Accessories/wordpad.exe">wordpad.exe (Windows wordpad editor)</a><br/>
         <a href="file:///usr/bin/subl">file:///usr/bin/subl (Linux open to sublime editor)</a><br/>
         <a href="file:///usr/bin/gnome-terminal">file:///usr/bin/gnome-terminal (Linux open terminal)</a><br/>
+        <a href="file:///usr/bin/konsole">file:///usr/bin/konsole (Linux open konsole)</a><br/>
+        <a href="file:///~/bin/sublime_text_3/sublime_text">file:///~/bin/sublime_text_3/sublime_text (Linux)</a>
 
     </body>
 </html>

--- a/test/webserver/issue16/index.html
+++ b/test/webserver/issue16/index.html
@@ -5,15 +5,7 @@
         <title>Issue 16 - executable links</title>
     </head>
     <body>
-        <h1>Test cases for whitelist settings of executable files. (Prevent denial of service attacks)</h1>
-        <p>
-            setting for Windows tests
-            whitelist exe entry = cmd.exe wordpad.exe
-        </p>
-        <p>
-            settings for Ubuntu tests (not tested yet)
-            usr/bin/sublime
-        </p>
+        <h1>Test cases for executable files. (Prevent denial of service attacks)</h1>
         <p>
             Additional test open containing folder should always work.
         </p>

--- a/test/webserver/issue16/index.html
+++ b/test/webserver/issue16/index.html
@@ -19,7 +19,8 @@
         </p>
         <a href="file://c:/windows/sysWOW64/cmd.exe">file://c:/windows/sysWOW64/cmd.exe (Windows command prompt)</a><br/>
         <a href="file://C:/Program Files (x86)/Windows NT/Accessories/wordpad.exe">wordpad.exe (Windows wordpad editor)</a><br/>
-        <a href="file://usr/bin/sublime">file://usr/bin/sublime (Linux open to sublime editor)</a><br/>
+        <a href="file:///usr/bin/subl">file:///usr/bin/subl (Linux open to sublime editor)</a><br/>
+        <a href="file:///usr/bin/gnome-terminal">file:///usr/bin/gnome-terminal (Linux open terminal)</a><br/>
 
     </body>
 </html>

--- a/test/webserver/issue16/index.html
+++ b/test/webserver/issue16/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Issue 16 - executable links</title>
+    </head>
+    <body>
+        <h1>Test cases for whitelist settings of executable files. (Prevent denial of service attacks)</h1>
+        <p>
+            setting for Windows tests
+            whitelist exe entry = cmd.exe wordpad.exe
+        </p>
+        <p>
+            settings for Ubuntu tests (not tested yet)
+            usr/bin/sublime
+        </p>
+        <p>
+            Additional test open containing folder should always work.
+        </p>
+        <a href="file://c:/windows/sysWOW64/cmd.exe">file://c:/windows/sysWOW64/cmd.exe (Windows command prompt)</a><br/>
+        <a href="file://C:/Program Files (x86)/Windows NT/Accessories/wordpad.exe">wordpad.exe (Windows wordpad editor)</a><br/>
+        <a href="file://usr/bin/sublime">file://usr/bin/sublime (Linux open to sublime editor)</a><br/>
+
+    </body>
+</html>

--- a/test/webserver/issue16/index.html
+++ b/test/webserver/issue16/index.html
@@ -17,12 +17,21 @@
         <p>
             Additional test open containing folder should always work.
         </p>
+        <h2>Windows</h2>
+        <p>
         <a href="file://c:/windows/sysWOW64/cmd.exe">file://c:/windows/sysWOW64/cmd.exe (Windows command prompt)</a><br/>
         <a href="file://C:/Program Files (x86)/Windows NT/Accessories/wordpad.exe">wordpad.exe (Windows wordpad editor)</a><br/>
+        <a href="file://C:/temp/test.bat">batch file c:/temp/test.bat (Windows batch file)</a><br/>
+        <a href="file://C:/temp/node.msi">installer file c:/temp/node.msi (Windows installer file)</a><br/>
+        <a href="file://C:/Windows/SysWOW64/tree.com">com file C:/Windows/SysWOW64/tree.com (Windows tree.com)</a><br/>
+        </p>
+        <hr/>
+        <h2>Linux</h2>
+        <p>
         <a href="file:///usr/bin/subl">file:///usr/bin/subl (Linux open to sublime editor)</a><br/>
         <a href="file:///usr/bin/gnome-terminal">file:///usr/bin/gnome-terminal (Linux open terminal)</a><br/>
         <a href="file:///usr/bin/konsole">file:///usr/bin/konsole (Linux open konsole)</a><br/>
         <a href="file:///~/bin/sublime_text_3/sublime_text">file:///~/bin/sublime_text_3/sublime_text (Linux)</a>
-
+    </p>
     </body>
 </html>


### PR DESCRIPTION
Added a preference to disable links to executable files by default (see issue #16).

It uses [`nsIFile.isExecutable()`](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIFile#isExecutable%28%29) to check if link is containing an executable file.

Tested with Windows and Linux. Both working. 

Linux can produce a strange behaviour for executable folders. E.g. /tmp folder in test case have x attribute and by default it will be blocked to open. But I think it is the correct behaviour.