### PR TITLE
added directory check - fix for false executable notification

### DIFF
--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -144,7 +144,9 @@ function start( path, reveal ) {
         if ( reveal ) {
             nsLocalFile.reveal();
         } else {
-            if ( nsLocalFile.isExecutable() && !allowAll ) {
+            if ( nsLocalFile.isExecutable() && !allowAll &&
+                !nsLocalFile.isDirectory() ) {
+                //console.log('is isExecutable', nsLocalFile, path, nsLocalFile.path);
                 notification.show( CONST.APP.name,
                     _('ERROR_EXECTUBALES_NOT_ENABLED'));
             } else {


### PR DESCRIPTION
@feinstaub I've added the directory check to the executable check so executable directories can be opened in Linux. That was the issue that you detected.

I think it's OK to ignore the executable attribute at directories and open them.

Can you please check if opening executable links is working for you? At my virtual machine it doesn't execute the file and opens an editor instead (Linux only, exe. links in Windows are working).
If this is an issue at your machine too we could open an issue and fix this later.

I'll add the exe-fix to master and add a new tag for this "0.99.45-1".