### PR TITLE
Environment path variable feature added

### DIFF
--- a/data/js/fileLinkAddonContent.js
+++ b/data/js/fileLinkAddonContent.js
@@ -92,11 +92,14 @@
     // Use delegate so the click event is also avaliable at newly added links
     $( document ).on( "click", fileLinkSelectors.join( ", " ), function( e ) {
         e.preventDefault(); // prevent default to avoid browser to launch smb://
-        //console.log( "clicked file link: " + this.href, options.revealOpenOption);
-        self.postMessage( {
-            action: options.revealOpenOption == "O" ? "open": "reveal",
-            url: decodeURIComponent( this.href )
-        } );
+        // console.log( "clicked file link: " + this.href, options.revealOpenOption);
+        
+        self.postMessage({ 
+            action: "open",
+            // removed decodeURIComponent because env. var. failed
+            url: this.href, //decodeURIComponent(this.href),
+            reveal: options.revealOpenOption == "O" ? false: true
+        });
     } );
 
     /*
@@ -108,16 +111,17 @@
 
         // console.log('clicked icon', link, options.revealOpenOption);
 
-        self.postMessage( {
-            action: options.revealOpenOption == "O" ? "reveal": "open",
-            // url: decodeURIComponent( $(e.currentTarget).data('link'))
-            url: decodeURIComponent(link),
-            backslashReplaceRequired: true // @todo check Linux too
-        } );
+        self.postMessage({ 
+            action: "open",
+            // removed decodeURIComponent because env. var. failed
+            url: link, //decodeURIComponent(link),
+            reveal: options.revealOpenOption == "O" ? true: false,
+            backslashReplaceRequired: true
+        });
     }
 
     // icon click handler
-    $( document ).on( "click", 
+    $(document).on("click", 
         "[class^='aliensun-link-icon']", // folder or arrow
         openFolderHandler);
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ var self = require( "sdk/self" ),
     attached = false,
     statusIcon = require('./lib/toolbar/statusIcon').create(false),
     tabs = require( "sdk/tabs" ),
-    { isUriIncluded } = require('./lib/utils/matchUrl');
+    { isUriIncluded } = require('./lib/utils/matchUrl'),
+    sysEnv = require('./lib/system-env-vars'),
+    curSysEnv = sysEnv();
 
 var jqueryScript = "js/jquery-1.11.3.min.js",
     jqueryObserveScript = "js/jquery-observe.js";
@@ -48,6 +50,7 @@ function onAttach( worker ) {
     */
     worker.on( "message", function( actionObj ) {
 
+        // console.log('onMessage', actionObj);
         if ( actionObj.backslashReplaceRequired ) {
             // special handling required at icon click
             actionObj.url = actionObj.url.replace(/\\/g, '/'); // replace backslashes
@@ -59,11 +62,12 @@ function onAttach( worker ) {
         switch ( actionObj.action ) {
             // Actions from content-script
             case "open":
-                launcher.start( actionObj.url );    
-            break;
+                // check if link contains a window path variable
+                // later add a option to enable env. paths vars?
+                // console.log('checklink', actionObj);
+                var replacedLink = curSysEnv.checkLink(actionObj.url);
 
-            case "reveal":
-                launcher.start( actionObj.url, true);
+                launcher.start(replacedLink, actionObj.reveal);
             break;
         }
 

--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -108,7 +108,7 @@ function getNsIFileFromPath ( path ) {
         nsiFile = new FileUtils.File( localPath );
     }
     catch(e) {
-        console.log('file error', e);
+        //console.log('file error', e);
         nsiFile = null;
     }
 
@@ -136,6 +136,7 @@ function start( path, reveal ) {
     // --> preference to enable backslash links not possible because we can't
     //     test for backslashes here
 
+    // console.log('opening path', path);
     var nsLocalFile = getNsIFileFromPath( path );
 
 
@@ -144,7 +145,9 @@ function start( path, reveal ) {
         if ( reveal ) {
             nsLocalFile.reveal();
         } else {
-            if ( nsLocalFile.isExecutable() && !allowAll ) {
+            if ( nsLocalFile.isExecutable() && !allowAll &&
+                !nsLocalFile.isDirectory() ) {
+                //console.log('is isExecutable', nsLocalFile, path, nsLocalFile.path);
                 notification.show( CONST.APP.name,
                     _('ERROR_EXECTUBALES_NOT_ENABLED'));
             } else {
@@ -190,8 +193,16 @@ function start( path, reveal ) {
             // better check the settings on pageMod attach
             notification.show( CONST.APP.name, _('INFO_CONFIG_CHANGE_SMB'));
         } else {
-            notification.show( CONST.APP.name, 
+            try {
+                // e.g. clicking on a link with %HOMEDRIVE%%HOMEPATH%
+                // in Linux will throw malformed URI sequence
+                notification.show( CONST.APP.name, 
                 _('ERROR_BAD_LINK', decodeURI(path)) );
+            }
+            catch(e) {
+                notification.show( CONST.APP.name, 
+                _('ERROR_BAD_LINK', ' - ' + e.message));
+            }
         }
     }
 }

--- a/lib/system-env-vars.js
+++ b/lib/system-env-vars.js
@@ -1,0 +1,42 @@
+// system-env-vars.js
+// check if link contains a path variable and 
+// add the real path into link to open into
+// Windows style %name%
+// Linux style $name$
+const { env } = require('sdk/system/environment');
+
+const {isWindowsOs} = require( './utils/os-util' );
+
+module.exports = function sysEnv() {
+    // required test
+    // - multiple path variables possible in link
+    // - How is it displayed in tooltip/statusbar?
+    // - Replace every occurence of a variable in the link
+
+    // regex to match %var_name% but not e.g. %20 encoding
+    var _currentEnvRegex = isWindowsOs() ? 
+        /\%(?!\d{2})\w+\%/g:
+        /\$(?!\d{2})\w+\$/g;
+
+    return {
+        checkLink: function(url) {
+            // %name% already removed --> Check where it is removed
+            var pathVars = url.match(_currentEnvRegex),
+                pathKey; // single path variable
+            // console.log('checkLink', _currentEnvRegex, pathVars, url);
+
+            if (pathVars !== null) {
+                for(var i=0; i < pathVars.length; i++) {
+                    pathKey = pathVars[i].replace(/(\%|\$)/g, ''); // remove % or $
+                    //console.log(pathKey, env[pathKey], env);
+                    url = url.replace(new RegExp(_currentEnvRegex.source), 
+                        env[pathKey] || ''); /// undefined will be changed to ''
+
+                    url = url.replace(/\\/g, '\/'); // replace backslashes
+                    // console.log('Replace', url, pathVars[i], env[pathKey]);
+                }
+            }
+            return url;
+        }
+    }
+}

--- a/lib/utils/os-util.js
+++ b/lib/utils/os-util.js
@@ -22,6 +22,7 @@ var retrieveIsWindowsOs = function() {
 const constIsWindowsOs = retrieveIsWindowsOs();
 
 var isWindowsOs = function() {
+    // console.log('isWindowsOs', constIsWindowsOs);
     return constIsWindowsOs;
 };
 exports.isWindowsOs = isWindowsOs;

--- a/test/webserver/index.htm
+++ b/test/webserver/index.htm
@@ -29,5 +29,8 @@ it does not if the page is served by a webserver; thats what the add-on is for).
 
 <p><a href="issue16/index.html">Issue 16 - security improvement</a>
     (<a href="https://github.com/feinstaub/firefox_addon_local_filesystem_links/issues/16">Issue 16</a>)</p>
+
+<p><a href="issue22/index.html">Issue 22 - Windows / Linux env. path varibales</a>
+    (<a href="https://github.com/feinstaub/firefox_addon_local_filesystem_links/issues/22">Issue 22</a>)</p>
 </body>
 </html>

--- a/test/webserver/issue22/index.html
+++ b/test/webserver/issue22/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Issue 22 - Windows / Linux path variables</title>
+    </head>
+    <body>
+        <h1>Test if we can open links with environment path variables e.g. %HOMEPATH%</h1>
+        <p>Why are three slashes required file:///%HOMEDRIVE%? With only two it will be relpace to file:///</p>
+        <p>Probably FF will remove %HOMEDRIVE% because it is not a valid uri.</p>
+        <h2>Info to env. var</h2>
+        <p>Windows list all env. variables with <strong>SET</strong> command.</p>
+        <p>Linux list all env. variables with <strong>printenv</strong> command.</p>
+        Windows setting: SET name=c:\<br/>
+        Linux setting: export name=/tmp<br/>
+        <h2>Windows</h2>
+        <ul>
+            <li><a href="file:///%HOMEDRIVE%%HOMEPATH%/">%HOMEPATH%/</a></li>
+            <li><a href="file://%HOMEDRIVE%%HOMEPATH%/">%HOMEPATH% with only two slashes file:// (not working)/</a></li>
+            <li><a href="file:///%LOCALAPPDATA%/">%LOCALAPPDATA%/</a></li>
+            <li><a href="file:///%LOCALAPPDATA%/blank in path/test.txt">%LOCALAPPDATA% with blanks in path C:\Users\%USERNAME%\AppData\Local\blank in path\test.txt/</a></li>
+        </ul>
+        <h2>Linux</h2>
+        <ul>
+            <li><a href="file:///$HOME$/">$HOME$/</a></li>
+            <li><a href="file:///$HOME$/path with space">$HOME$/path with space</a></li>
+            <li><a href="file:///$TMPDIR$/">$TMPDIR$ set with export TMPDIR="/tmp"</a></li>
+            <li><a href="file:///$TMPDIR$/$TEST$/test.txt">$TMPDIR$ $TEST set with export TEST="test" (combined $TMPDIR$TEST/test.txt)</a></li>
+        </ul>
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
I've added the requested feature of issue #22. It's working for Linux and Windows.

Please notice that three slashes are required to make it work. e.g. `file:///$home$` Not exactly sure why two slashes are not working but I think FF is replacing the non-standard link so that it is not working as expected. But I think it's OK to use tripple slashes for this special feature.

Combining multiple environment path variables in one url is also working correctly. I've added a test page to the webserver for testing. (Linux required setting some path variables and creating some folders to test.)

I've removed `decodeUriComponent` from the code because it affected the checking of the env. var. links. I couldn't detect any issues after removing it. Do you think it is required?

**The following points are not implemented (could be added later)**:
- Path is not replaced inside of FF so statusbar will show the env. variable and not the final target (see screenshot below). I think that's OK because replacing is more code and more complicated to write (check every link on page and replace if env. var detected). At the moment, the check is light-weight and only executed before opening the file link. ![screenshot of statusbar](http://i.imgur.com/NPbXjCj.png)
- There could be an option to disable the enviornment path usage. But I think there should be no security issues. So my opinion is that the option is not really needed.

@feinstaub Please review this feature after releasing 0.99.45-1. I think this feature is not that important and can be added in a future release.
(code style checker not added with this feature. I'll add this in a separate branch.)