### PR TITLE
Code style - Google style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,19 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 5,
+        "sourceType": "module",
+    },
+    "extends": "defaults/configurations/google",
+    "env": {
+        "browser": true,
+        "node": true
+    },
+    "rules": {
+        "no-console": "off",
+        "no-invalid-this": 0,
+        "new-cap": [0, {newIsCap: false}]
+    },
+    "globals": {
+        "jQuery": true
+    }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,8 @@
     "rules": {
         "no-console": "off",
         "no-invalid-this": 0,
-        "new-cap": [0, {newIsCap: false}]
+        "new-cap": [0, {newIsCap: false}],
+        "indent": ["error", 4]
     },
     "globals": {
         "jQuery": true

--- a/.jpmignore
+++ b/.jpmignore
@@ -13,3 +13,5 @@ node_modules/
 reviews/
 test/
 TODO
+.eslintrc
+gulpfile.js

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Features
 - Supports links with double and tripple slashes (e.g. file:// or file:///)
 - Right click context menu that opens a text selection that contains a file link + option to reveal the directory of a directly linked file.
 - Whitelist option to enable local links only at a specific url e.g. `*.trello.com`
+- Statusbar icon for displaying if links are active for current tab & for easier access to addon settings
+- Option to change the default text link behaviour (open or reveal)
+- Localization (current languages German, English, Russian)
 
 
 Screenshots
@@ -48,6 +51,15 @@ In Node.js command prompt:
 ```
 npm install jpm -g
 ```
+
+***Install npm dependencies***
+`npm install`
+
+If gulp is required globally use `npm install gulp -g`.
+
+***Linting your code***
+Running `gulp` will watch all js files and repeats linting on change.
+With `gulp lint` you can do a one time lint.
 
 ***Run various jpm commands.***
 

--- a/data/js/fileLinkAddonContent.js
+++ b/data/js/fileLinkAddonContent.js
@@ -92,11 +92,14 @@
     // Use delegate so the click event is also avaliable at newly added links
     $( document ).on( "click", fileLinkSelectors.join( ", " ), function( e ) {
         e.preventDefault(); // prevent default to avoid browser to launch smb://
-        //console.log( "clicked file link: " + this.href, options.revealOpenOption);
-        self.postMessage( {
-            action: options.revealOpenOption == "O" ? "open": "reveal",
-            url: decodeURIComponent( this.href )
-        } );
+        // console.log( "clicked file link: " + this.href, options.revealOpenOption);
+        
+        self.postMessage({ 
+            action: "open",
+            // removed decodeURIComponent because env. var. failed
+            url: this.href, //decodeURIComponent(this.href),
+            reveal: options.revealOpenOption == "O" ? false: true
+        });
     } );
 
     /*
@@ -108,16 +111,17 @@
 
         // console.log('clicked icon', link, options.revealOpenOption);
 
-        self.postMessage( {
-            action: options.revealOpenOption == "O" ? "reveal": "open",
-            // url: decodeURIComponent( $(e.currentTarget).data('link'))
-            url: decodeURIComponent(link),
-            backslashReplaceRequired: true // @todo check Linux too
-        } );
+        self.postMessage({ 
+            action: "open",
+            // removed decodeURIComponent because env. var. failed
+            url: link, //decodeURIComponent(link),
+            reveal: options.revealOpenOption == "O" ? true: false,
+            backslashReplaceRequired: true
+        });
     }
 
     // icon click handler
-    $( document ).on( "click", 
+    $(document).on("click", 
         "[class^='aliensun-link-icon']", // folder or arrow
         openFolderHandler);
 

--- a/data/js/fileLinkAddonContent.js
+++ b/data/js/fileLinkAddonContent.js
@@ -1,239 +1,225 @@
-"use strict";
+'use strict';
 
-( function fileLinkAddon( $, self ) {
+(function fileLinkAddon($, self) {
 
-    $.noConflict();
+  $.noConflict();
 
-    var fileLinkSelectors = [
-            'a[href^="file:"]',
-            /*'a[href^="smb://"]',
-            'a[href^="afp://"]'*/
-        ],
-        appTextMessages = {
-            // every constant text we're showing the user
-            // e.g. tooltip text constants
-        },
-        $container = $('<span/>'), //$('<span class="aliensun-link-icon"/>'),
-        $icon = {}, // loading, see init
-        options = {
-            //enableLinkIcons: self.options.enableLinkIcons
-        },
-        tooltipFilemanagerText, // not used yet?
-        appName,            // where is it used?
-        latestNodesAdded,
-        currentIconClass; // folder or arrow?
+  var fileLinkSelectors = [
+      'a[href^="file:"]'
+      /*'a[href^="smb://"]',
+      'a[href^="afp://"]'*/
+    ],
+    appTextMessages = {
+      // every constant text we're showing the user
+      // e.g. tooltip text constants
+    },
+    $container = $('<span/>'), //$('<span class="aliensun-link-icon"/>'),
+    $icon = {}, // loading, see init
+    options = {
+      //enableLinkIcons: self.options.enableLinkIcons
+    },
+    currentIconClass; // folder or arrow?
 
-    function updateLinkTooltip() {
-        var tooltipText = options.revealOpenOption == "O" ?
-            appTextMessages.tooltips.linkText:
-            appTextMessages.tooltips.openFolder;
+  function updateLinkTooltip() {
+    var tooltipText = options.revealOpenOption == 'O' ?
+      appTextMessages.tooltips.linkText :
+      appTextMessages.tooltips.openFolder;
 
-        $('a').filter(fileLinkSelectors.join(', '))
-            .attr('title', tooltipText);
+    $('a').filter(fileLinkSelectors.join(', ')).attr('title', tooltipText);
+  }
+
+  /*
+  * Activates the plugin - add icon after link and starts observer if enabled
+  */
+  function activate() {
+    // console.log(options);
+    if (options.enableLinkIcons) {
+      currentIconClass = 'aliensun-link-icon' +
+      (options.revealOpenOption == 'R' ? '-arrow' : '');
+
+      createObserver();
+      $container.addClass(currentIconClass);
+
+      updateLink($(fileLinkSelectors.join(', ')));
     }
 
-    /**
-     * Activates the plugin - add icon after link and starts observer if enabled
-     */
-    function activate() {
-        // console.log(options);
-        if ( options.enableLinkIcons ) {
-            currentIconClass = "aliensun-link-icon" + 
-                ( options.revealOpenOption == "R"? "-arrow": "" );
+    // we could add a if case here to add tooltip disable pref.
+    updateLinkTooltip();
+  }
 
-            createObserver();
-            $container.addClass(currentIconClass);
+  // Get settings from addon
+  self.port.on('init', function(addonOptions, constants) {
+    // console.log('init', addonOptions, constants);
+    appTextMessages = constants.MESSAGES.USERMESSAGES;
 
-            updateLink($(fileLinkSelectors.join(', ')));
-        }
+    // load plugin options
+    options = addonOptions;
 
-        // we could add a if case here to add tooltip disable pref.
-        updateLinkTooltip();
+    // console.log('test', appTextMessages);
+    $icon = $container.append($('<i/>').addClass('material-icons'));
+
+    // now everything is ready to load
+    activate();
+  });
+
+  // Update settings on change of pref.
+  function updateIcons(data) {
+    options = $.extend({}, options, data);
+
+    // console.log('pref changed', data, options);
+    removeLinkIcons();
+    updateLinkTooltip();
+
+    if (options.enableLinkIcons) {
+      updateLink($(fileLinkSelectors.join(', ')));
     }
+  }
 
-    // Get settings from addon
-    self.port.on( "init", function( addonOptions, constants) {
-        // console.log('init', addonOptions, constants);
-        appTextMessages = constants.MESSAGES.USERMESSAGES;
+  self.port.on('prefChange:enableLinkIcons', updateIcons);
+  self.port.on('prefChange:revealOpenOption', updateIcons);
 
-        // load plugin options
-        options = addonOptions;
+  // Use delegate so the click event is also avaliable at newly added links
+  $(document).on('click', fileLinkSelectors.join(', '), function(e) {
+    e.preventDefault(); // prevent default to avoid browser to launch smb://
+    // console.log( "clicked file link: " + this.href, options.revealOpenOption);
 
-        // load constant texts from addon
-        tooltipFilemanagerText = constants.MESSAGES.FILEMANAGER;
-        appName = constants.APP.name;
-        // console.log('test', appTextMessages);
-        $icon = $container.append($( "<i/>" )
-                            // .attr("title",
-                            //     iconTooltip)
-                            .addClass( "material-icons" )
-                    );
+    self.postMessage({
+      action: 'open',
+      // removed decodeURIComponent because env. var. failed
+      url: this.href, //decodeURIComponent(this.href),
+      reveal: options.revealOpenOption == 'O' ? false : true
+    });
+  });
 
-        // now everything is ready to load
-        activate();
-    } );
+  /*
+  Event for icon to reveal the folder directly
+  */
+  function openFolderHandler(e) {
+    var link = $(e.currentTarget).data('link');
 
-    // Update settings on change of pref.
-    function updateIcons(data) {
-        options = $.extend({}, options, data);
+    e.preventDefault();
 
-        // console.log('pref changed', data, options);
-        removeLinkIcons();
-        updateLinkTooltip();
-        
-        if ( options.enableLinkIcons ) {
-            updateLink($(fileLinkSelectors.join(', ')));
-        }
-    }
+    // console.log('clicked icon', link, options.revealOpenOption);
 
-    self.port.on( "prefChange:enableLinkIcons", updateIcons);
-    self.port.on( "prefChange:revealOpenOption", updateIcons);
+    self.postMessage({
+      action: 'open',
+      // removed decodeURIComponent because env. var. failed
+      url: link, //decodeURIComponent(link),
+      reveal: options.revealOpenOption == 'O' ? true : false,
+      backslashReplaceRequired: true
+    });
+  }
 
-    // Use delegate so the click event is also avaliable at newly added links
-    $( document ).on( "click", fileLinkSelectors.join( ", " ), function( e ) {
-        e.preventDefault(); // prevent default to avoid browser to launch smb://
-        // console.log( "clicked file link: " + this.href, options.revealOpenOption);
-        
-        self.postMessage({ 
-            action: "open",
-            // removed decodeURIComponent because env. var. failed
-            url: this.href, //decodeURIComponent(this.href),
-            reveal: options.revealOpenOption == "O" ? false: true
+  // icon click handler
+  $(document).on('click',
+    '[class^=\'aliensun-link-icon\']',// folder or arrow
+    openFolderHandler);
+
+  // -------------------------------------------------------------------------
+  // add link icons (if enabled)
+  //
+  // Check at every click if there are new a-tags
+  // almost works, there is an issue if the content is loaded with ajax it will fail
+  // because at the moment after click there is no new link icon
+  //
+  // Ideas to add the icons (only needed if we need to add icons to DOM):
+  // - add one timeout after click --> probably the easiest way but it could fails
+  //   if the request is taking longer
+  // - check if we can detect that all ajax requests are resolved and then check for updated dom
+  // - use mutationObserver will work but could be a lot to execute if there is many
+  //   content added to the DOM
+  // - use an interval (every second) that's checking if there is a new link
+  //
+  // A timeout was OK at the beginning because the icons will be checked after any click
+  //
+  // -->better check if there are new links with an interval if the icons are enabled.
+  //    if they're disabled we don't need an interval (works also for ajax added content)
+  //
+  // --> final solution: use jquery-observe that's simplyfing mutationObserver
+
+  function updateLink($element) {
+    // console.log('updating', $element);
+    var iconTooltip = options.revealOpenOption == 'O' ?
+    appTextMessages.tooltips.openFolder :
+    appTextMessages.tooltips.linkText;
+
+    // update class (folder or arrow)
+    currentIconClass = 'aliensun-link-icon' +
+    (options.revealOpenOption == 'R' ? '-arrow' : '');
+
+    $container.removeClass();
+    $container.addClass(currentIconClass);
+
+    $element.each(function(index, el) {
+      // console.log('el href = ', $(el).attr('href'));
+      $icon.
+        attr('title', iconTooltip).
+        clone().data('link', $(el).attr('href')). // added to container
+        insertAfter($(el));
+    });
+  }
+
+  /*
+  * Remove all link icons
+  * (needed for updating at icon pref. change)
+  */
+  function removeLinkIcons() {
+    var $icons = $('.aliensun-link-icon, .aliensun-link-icon-arrow');
+    // console.log('test',$icons);
+
+    $icons.remove();
+  }
+
+  /*
+  * Create observers for file links
+  * Two observers - one for href attributes and another one for newly added file links
+  */
+  function createObserver() {
+    // observe changes of file links
+    // create an observer if someone is changing an a-tag directly
+    $(fileLinkSelectors.join(', ')).
+      observe({attributes: true, attributeFilter: ['href']},
+      function(/* record */) {
+    // observe href change
+    //console.log('changed href', $(this), $icon.attr('class'));
+
+        $(this).next('.' + $icon.attr('class')).remove(); // remove previous icon
+        updateLink($(this)); // add new icons so we have the correct data at the icon
+      });
+
+    // observe newly added file links
+    $(document).
+      observe('added', fileLinkSelectors.join(', '),
+      function(/* record */) {
+        // Observe if elements matching 'a[href^="file://"]' have been added
+        //
+        // there can be multiple observer callbacks attached now!!
+        // --> if you add three links you'll get three callback events
+        //     with the same elements
+        //     --> store elements in first observer,
+        //         so next observer callback detect that there is
+        //         nothing new
+        //
+        // Info:
+        // That's working but it would be better to not trigger
+        // these callbacks but I'm not sure how to fix.
+        // --> asked if it could be fixed,
+        //     see here https://github.com/kapetan/jquery-observe/issues/5
+        //
+        // Update: 09.03.2016
+        // We're getting only one observer callback for each added element.
+        // So we don't need to store the previous added node.
+
+        //console.log('link added');
+        // console.log($(this).eq(0).html(), record); // this = addedNodes
+
+        // get elements that are with-out icon - avoid multiple icons
+        var $elements = $(this).filter(function(/* index, item */) {
+          return !$(this).
+            next().is('.aliensun-link-icon,.aliensun-link-icon-arrow');
         });
-    } );
 
-    /*
-      Event for icon to reveal the folder directly
-    */
-    function openFolderHandler(e) {
-        var link = $(e.currentTarget).data('link');
-        e.preventDefault();
-
-        // console.log('clicked icon', link, options.revealOpenOption);
-
-        self.postMessage({ 
-            action: "open",
-            // removed decodeURIComponent because env. var. failed
-            url: link, //decodeURIComponent(link),
-            reveal: options.revealOpenOption == "O" ? true: false,
-            backslashReplaceRequired: true
-        });
-    }
-
-    // icon click handler
-    $(document).on("click", 
-        "[class^='aliensun-link-icon']", // folder or arrow
-        openFolderHandler);
-
-    // -------------------------------------------------------------------------
-    // add link icons (if enabled)
-    //
-    // Check at every click if there are new a-tags
-    // almost works, there is an issue if the content is loaded with ajax it will fail
-    // because at the moment after click there is no new link icon
-    //
-    // Ideas to add the icons (only needed if we need to add icons to DOM):
-    // - add one timeout after click --> probably the easiest way but it could fails
-    //   if the request is taking longer
-    // - check if we can detect that all ajax requests are resolved and then check for updated dom
-    // - use mutationObserver will work but could be a lot to execute if there is many
-    //   content added to the DOM
-    // - use an interval (every second) that's checking if there is a new link
-    //
-    // A timeout was OK at the beginning because the icons will be checked after any click
-    //
-    // -->better check if there are new links with an interval if the icons are enabled.
-    //    if they're disabled we don't need an interval (works also for ajax added content)
-    //
-    // --> final solution: use jquery-observe that's simplyfing mutationObserver
-
-    function updateLink($element) {
-        // console.log('updating', $element);
-        var iconTooltip = options.revealOpenOption == "O" ? 
-            appTextMessages.tooltips.openFolder :
-            appTextMessages.tooltips.linkText;
-
-        // update class (folder or arrow)
-        currentIconClass = "aliensun-link-icon" + 
-                ( options.revealOpenOption == "R"? "-arrow": "" );
-
-        $container.removeClass();
-        $container.addClass(currentIconClass);
-
-        $element.each(function(index, el) {
-            // console.log('el href = ', $(el).attr('href'));
-            $icon
-                .attr("title", iconTooltip)
-                .clone()
-                .data('link', $(el).attr('href')) // added to container
-                .insertAfter($(el));
-        });
-    }
-
-    /**
-      * Remove all link icons
-      * (needed for updating at icon pref. change)
-      */
-    function removeLinkIcons() {
-        var $icons = $('.aliensun-link-icon, .aliensun-link-icon-arrow');
-        // console.log('test',$icons);
-
-        $icons.remove();
-    }
-
-    /**
-      * Create observers for file links
-      * Two observers - one for href attributes and another one for newly added file links
-      */
-    function createObserver() {
-        // observe changes of file links
-
-        // create an observer if someone is changing an a-tag directly
-        $(fileLinkSelectors.join(', '))
-            .observe({ attributes: true, attributeFilter: ['href'] },
-                function(record) {
-                // observe href change
-                //console.log('changed href', $(this), $icon.attr('class'));
-
-                $(this).next('.' + $icon.attr('class')).remove(); // remove previous icon
-                updateLink($(this)); // add new icons so we have the correct data at the icon
-        });
-
-        // observe newly added file links
-        $(document)
-            .observe('added', fileLinkSelectors.join(', '),
-                function(record) {
-            // Observe if elements matching 'a[href^="file://"]' have been added
-            //
-            // there can be multiple observer callbacks attached now!!
-            // --> if you add three links you'll get three callback events
-            //     with the same elements
-            //     --> store elements in first observer,
-            //         so next observer callback detect that there is
-            //         nothing new
-            //
-            // Info:
-            // That's working but it would be better to not trigger
-            // these callbacks but I'm not sure how to fix.
-            // --> asked if it could be fixed,
-            //     see here https://github.com/kapetan/jquery-observe/issues/5
-            //
-            // Update: 09.03.2016
-            // We're getting only one observer callback for each added element.
-            // So we don't need to store the previous added node.
-
-            //console.log('link added');
-            // console.log($(this).eq(0).html(), record); // this = addedNodes
-
-            // get elements that are with-out icon - avoid multiple icons
-            var $elements = $(this).filter(function(index, item) {
-                return !$(this)
-                    .next().is('.aliensun-link-icon,.aliensun-link-icon-arrow');
-            });
-
-            updateLink($elements);
-      })
-    }
-
-
-}( jQuery, window.self ) );
+        updateLink($elements);
+      });
+  }
+}(jQuery, window.self));

--- a/data/js/fileLinkAddonContent.js
+++ b/data/js/fileLinkAddonContent.js
@@ -2,224 +2,233 @@
 
 (function fileLinkAddon($, self) {
 
-  $.noConflict();
+    $.noConflict();
 
-  var fileLinkSelectors = [
-      'a[href^="file:"]'
-      /*'a[href^="smb://"]',
-      'a[href^="afp://"]'*/
-    ],
-    appTextMessages = {
-      // every constant text we're showing the user
-      // e.g. tooltip text constants
-    },
-    $container = $('<span/>'), //$('<span class="aliensun-link-icon"/>'),
-    $icon = {}, // loading, see init
-    options = {
-      //enableLinkIcons: self.options.enableLinkIcons
-    },
-    currentIconClass; // folder or arrow?
+    var fileLinkSelectors = [
+            'a[href^="file:"]'
+            /*'a[href^="smb://"]',
+            'a[href^="afp://"]'*/
+        ],
+        appTextMessages = {
+            // every constant text we're showing the user
+            // e.g. tooltip text constants
+        },
+        $container = $('<span/>'), //$('<span class="aliensun-link-icon"/>'),
+        $icon = {}, // loading, see init
+        options = {
+            //enableLinkIcons: self.options.enableLinkIcons
+        },
+        currentIconClass; // folder or arrow?
 
-  function updateLinkTooltip() {
-    var tooltipText = options.revealOpenOption == 'O' ?
-      appTextMessages.tooltips.linkText :
-      appTextMessages.tooltips.openFolder;
+    function updateLinkTooltip() {
+        var tooltipText = options.revealOpenOption == 'O' ?
+        appTextMessages.tooltips.linkText :
+        appTextMessages.tooltips.openFolder;
 
-    $('a').filter(fileLinkSelectors.join(', ')).attr('title', tooltipText);
-  }
-
-  /*
-  * Activates the plugin - add icon after link and starts observer if enabled
-  */
-  function activate() {
-    // console.log(options);
-    if (options.enableLinkIcons) {
-      currentIconClass = 'aliensun-link-icon' +
-      (options.revealOpenOption == 'R' ? '-arrow' : '');
-
-      createObserver();
-      $container.addClass(currentIconClass);
-
-      updateLink($(fileLinkSelectors.join(', ')));
+        $('a').filter(fileLinkSelectors.join(', ')).attr('title', tooltipText);
     }
 
-    // we could add a if case here to add tooltip disable pref.
-    updateLinkTooltip();
-  }
+    /*
+    * Activates the plugin - add icon after link and starts observer if enabled
+    */
+    function activate() {
+        // console.log(options);
+        if (options.enableLinkIcons) {
+            currentIconClass = 'aliensun-link-icon' +
+            (options.revealOpenOption == 'R' ? '-arrow' : '');
 
-  // Get settings from addon
-  self.port.on('init', function(addonOptions, constants) {
-    // console.log('init', addonOptions, constants);
-    appTextMessages = constants.MESSAGES.USERMESSAGES;
+            createObserver();
+            $container.addClass(currentIconClass);
 
-    // load plugin options
-    options = addonOptions;
+            updateLink($(fileLinkSelectors.join(', ')));
+        }
 
-    // console.log('test', appTextMessages);
-    $icon = $container.append($('<i/>').addClass('material-icons'));
-
-    // now everything is ready to load
-    activate();
-  });
-
-  // Update settings on change of pref.
-  function updateIcons(data) {
-    options = $.extend({}, options, data);
-
-    // console.log('pref changed', data, options);
-    removeLinkIcons();
-    updateLinkTooltip();
-
-    if (options.enableLinkIcons) {
-      updateLink($(fileLinkSelectors.join(', ')));
+        // we could add a if case here to add tooltip disable pref.
+        updateLinkTooltip();
     }
-  }
 
-  self.port.on('prefChange:enableLinkIcons', updateIcons);
-  self.port.on('prefChange:revealOpenOption', updateIcons);
+    // Get settings from addon
+    self.port.on('init', function(addonOptions, constants) {
+        // console.log('init', addonOptions, constants);
+        appTextMessages = constants.MESSAGES.USERMESSAGES;
 
-  // Use delegate so the click event is also avaliable at newly added links
-  $(document).on('click', fileLinkSelectors.join(', '), function(e) {
-    e.preventDefault(); // prevent default to avoid browser to launch smb://
-    // console.log( "clicked file link: " + this.href, options.revealOpenOption);
+        // load plugin options
+        options = addonOptions;
 
-    self.postMessage({
-      action: 'open',
-      // removed decodeURIComponent because env. var. failed
-      url: this.href, //decodeURIComponent(this.href),
-      reveal: options.revealOpenOption == 'O' ? false : true
+        // console.log('test', appTextMessages);
+        $icon = $container.append($('<i/>').addClass('material-icons'));
+
+        // now everything is ready to load
+        activate();
     });
-  });
 
-  /*
-  Event for icon to reveal the folder directly
-  */
-  function openFolderHandler(e) {
-    var link = $(e.currentTarget).data('link');
+    // Update settings on change of pref.
+    function updateIcons(data) {
+        options = $.extend({}, options, data);
 
-    e.preventDefault();
+        // console.log('pref changed', data, options);
+        removeLinkIcons();
+        updateLinkTooltip();
 
-    // console.log('clicked icon', link, options.revealOpenOption);
+        if (options.enableLinkIcons) {
+            updateLink($(fileLinkSelectors.join(', ')));
+        }
+    }
 
-    self.postMessage({
-      action: 'open',
-      // removed decodeURIComponent because env. var. failed
-      url: link, //decodeURIComponent(link),
-      reveal: options.revealOpenOption == 'O' ? true : false,
-      backslashReplaceRequired: true
+    self.port.on('prefChange:enableLinkIcons', updateIcons);
+    self.port.on('prefChange:revealOpenOption', updateIcons);
+
+    // Use delegate so the click event is also avaliable at newly added links
+    $(document).on('click', fileLinkSelectors.join(', '), function(e) {
+        e.preventDefault(); // prevent default to avoid browser to launch smb://
+        // console.log( "clicked file link: " + this.href, options.revealOpenOption);
+
+        self.postMessage({
+            action: 'open',
+            // removed decodeURIComponent because env. var. failed
+            url: this.href, //decodeURIComponent(this.href),
+            reveal: options.revealOpenOption == 'O' ? false : true
+        });
     });
-  }
 
-  // icon click handler
-  $(document).on('click',
+    /*
+    Event for icon to reveal the folder directly
+    */
+    function openFolderHandler(e) {
+        var link = $(e.currentTarget).data('link');
+
+        e.preventDefault();
+
+        // console.log('clicked icon', link, options.revealOpenOption);
+
+        self.postMessage({
+            action: 'open',
+            // removed decodeURIComponent because env. var. failed
+            url: link, //decodeURIComponent(link),
+            reveal: options.revealOpenOption == 'O' ? true : false,
+            backslashReplaceRequired: true
+        });
+    }
+
+    // icon click handler
+    $(document).on('click',
     '[class^=\'aliensun-link-icon\']',// folder or arrow
     openFolderHandler);
 
-  // -------------------------------------------------------------------------
-  // add link icons (if enabled)
-  //
-  // Check at every click if there are new a-tags
-  // almost works, there is an issue if the content is loaded with ajax it will fail
-  // because at the moment after click there is no new link icon
-  //
-  // Ideas to add the icons (only needed if we need to add icons to DOM):
-  // - add one timeout after click --> probably the easiest way but it could fails
-  //   if the request is taking longer
-  // - check if we can detect that all ajax requests are resolved and then check for updated dom
-  // - use mutationObserver will work but could be a lot to execute if there is many
-  //   content added to the DOM
-  // - use an interval (every second) that's checking if there is a new link
-  //
-  // A timeout was OK at the beginning because the icons will be checked after any click
-  //
-  // -->better check if there are new links with an interval if the icons are enabled.
-  //    if they're disabled we don't need an interval (works also for ajax added content)
-  //
-  // --> final solution: use jquery-observe that's simplyfing mutationObserver
+    // -------------------------------------------------------------------------
+    // add link icons (if enabled)
+    //
+    // Check at every click if there are new a-tags
+    // almost works, there is an issue if the content is loaded
+    // with ajax it will fail because at the moment after click
+    // there is no new link icon
+    //
+    // Ideas to add the icons (only needed if we need to add icons to DOM):
+    // - add one timeout after click
+    //   --> probably the easiest way but it could fails
+    //   if the request is taking longer
+    // - check if we can detect that all ajax requests are resolved and then
+    //   check for updated dom
+    // - use mutationObserver will work but could be a lot to execute if there
+    //   is many content added to the DOM
+    // - use an interval (every second) that's checking if there is a new link
+    //
+    // A timeout was OK at the beginning because the icons will be checked after
+    // any click
+    //
+    // -->better check if there are new links with an interval if the icons
+    //    are enabled.
+    //    if they're disabled we don't need an interval
+    //    (works also for ajax added content)
+    //
+    // --> final solution: use jquery-observe that's simplyfing mutationObserver
 
-  function updateLink($element) {
-    // console.log('updating', $element);
-    var iconTooltip = options.revealOpenOption == 'O' ?
-    appTextMessages.tooltips.openFolder :
-    appTextMessages.tooltips.linkText;
+    function updateLink($element) {
+        // console.log('updating', $element);
+        var iconTooltip = options.revealOpenOption == 'O' ?
+        appTextMessages.tooltips.openFolder :
+        appTextMessages.tooltips.linkText;
 
-    // update class (folder or arrow)
-    currentIconClass = 'aliensun-link-icon' +
-    (options.revealOpenOption == 'R' ? '-arrow' : '');
+        // update class (folder or arrow)
+        currentIconClass = 'aliensun-link-icon' +
+        (options.revealOpenOption == 'R' ? '-arrow' : '');
 
-    $container.removeClass();
-    $container.addClass(currentIconClass);
+        $container.removeClass();
+        $container.addClass(currentIconClass);
 
-    $element.each(function(index, el) {
-      // console.log('el href = ', $(el).attr('href'));
-      $icon.
-        attr('title', iconTooltip).
-        clone().data('link', $(el).attr('href')). // added to container
-        insertAfter($(el));
-    });
-  }
+        $element.each(function(index, el) {
+            // console.log('el href = ', $(el).attr('href'));
+            $icon.
+            attr('title', iconTooltip).
+            clone().data('link', $(el).attr('href')). // added to container
+            insertAfter($(el));
+        });
+    }
 
-  /*
-  * Remove all link icons
-  * (needed for updating at icon pref. change)
-  */
-  function removeLinkIcons() {
-    var $icons = $('.aliensun-link-icon, .aliensun-link-icon-arrow');
-    // console.log('test',$icons);
+    /*
+    * Remove all link icons
+    * (needed for updating at icon pref. change)
+    */
+    function removeLinkIcons() {
+        var $icons = $('.aliensun-link-icon, .aliensun-link-icon-arrow');
+        // console.log('test',$icons);
 
-    $icons.remove();
-  }
+        $icons.remove();
+    }
 
-  /*
-  * Create observers for file links
-  * Two observers - one for href attributes and another one for newly added file links
-  */
-  function createObserver() {
-    // observe changes of file links
-    // create an observer if someone is changing an a-tag directly
-    $(fileLinkSelectors.join(', ')).
-      observe({attributes: true, attributeFilter: ['href']},
-      function(/* record */) {
-    // observe href change
-    //console.log('changed href', $(this), $icon.attr('class'));
+    /*
+    * Create observers for file links
+    * Two observers - one for href attributes and
+    * another one for newly added file links
+    */
+    function createObserver() {
+        // observe changes of file links
+        // create an observer if someone is changing an a-tag directly
+        $(fileLinkSelectors.join(', ')).
+        observe({attributes: true, attributeFilter: ['href']},
+        function(/* record */) {
+            // observe href change
+            //console.log('changed href', $(this), $icon.attr('class'));
 
-        $(this).next('.' + $icon.attr('class')).remove(); // remove previous icon
-        updateLink($(this)); // add new icons so we have the correct data at the icon
-      });
-
-    // observe newly added file links
-    $(document).
-      observe('added', fileLinkSelectors.join(', '),
-      function(/* record */) {
-        // Observe if elements matching 'a[href^="file://"]' have been added
-        //
-        // there can be multiple observer callbacks attached now!!
-        // --> if you add three links you'll get three callback events
-        //     with the same elements
-        //     --> store elements in first observer,
-        //         so next observer callback detect that there is
-        //         nothing new
-        //
-        // Info:
-        // That's working but it would be better to not trigger
-        // these callbacks but I'm not sure how to fix.
-        // --> asked if it could be fixed,
-        //     see here https://github.com/kapetan/jquery-observe/issues/5
-        //
-        // Update: 09.03.2016
-        // We're getting only one observer callback for each added element.
-        // So we don't need to store the previous added node.
-
-        //console.log('link added');
-        // console.log($(this).eq(0).html(), record); // this = addedNodes
-
-        // get elements that are with-out icon - avoid multiple icons
-        var $elements = $(this).filter(function(/* index, item */) {
-          return !$(this).
-            next().is('.aliensun-link-icon,.aliensun-link-icon-arrow');
+            // remove previous icon
+            $(this).next('.' + $icon.attr('class')).remove();
+            // add new icons so we have the correct data at the icon
+            updateLink($(this));
         });
 
-        updateLink($elements);
-      });
-  }
+        // observe newly added file links
+        $(document).
+        observe('added', fileLinkSelectors.join(', '),
+        function(/* record */) {
+            // Observe if elements matching 'a[href^="file://"]' have been added
+            //
+            // there can be multiple observer callbacks attached now!!
+            // --> if you add three links you'll get three callback events
+            //     with the same elements
+            //     --> store elements in first observer,
+            //         so next observer callback detect that there is
+            //         nothing new
+            //
+            // Info:
+            // That's working but it would be better to not trigger
+            // these callbacks but I'm not sure how to fix.
+            // --> asked if it could be fixed,
+            //     see here https://github.com/kapetan/jquery-observe/issues/5
+            //
+            // Update: 09.03.2016
+            // We're getting only one observer callback for each added element.
+            // So we don't need to store the previous added node.
+
+            //console.log('link added');
+            // console.log($(this).eq(0).html(), record); // this = addedNodes
+
+            // get elements that are with-out icon - avoid multiple icons
+            var $elements = $(this).filter(function(/* index, item */) {
+                return !$(this).
+                next().is('.aliensun-link-icon,.aliensun-link-icon-arrow');
+            });
+
+            updateLink($elements);
+        });
+    }
 }(jQuery, window.self));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ var eslint = require('gulp-eslint');
  
 var sourceFiles = [
     'index.js', 
-    'lib/js/*.js', 
+    'lib/**/*.js', 
     '!data/js/jquery*.js',
     '!data/js/jquery-observe.js',
     'data/js/*.js'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,36 @@
+var gulp = require('gulp');
+var watch = require('gulp-watch');
+var eslint = require('gulp-eslint');
+ 
+var sourceFiles = [
+    'index.js', 
+    'lib/js/*.js', 
+    '!data/js/jquery*.js',
+    '!data/js/jquery-observe.js',
+    'data/js/*.js'
+];
+
+gulp.task('lint', function() {
+    // ESLint ignores files with "node_modules" paths. 
+    // So, it's best to have gulp ignore the directory as well. 
+    // Also, Be sure to return the stream from the task; 
+    // Otherwise, the task may end before the stream has finished. 
+    // return gulp.src(['**/*.js','!node_modules/**'])
+    return gulp.src(sourceFiles)
+            //'!node_modules/**'])
+        // eslint() attaches the lint output to the "eslint" property 
+        // of the file object so it can be used by other modules. 
+        .pipe(eslint())
+        // eslint.format() outputs the lint results to the console. 
+        // Alternatively use eslint.formatEach() (see Docs). 
+        .pipe(eslint.format())
+        // To have the process exit with an error code (1) on 
+        // lint error, return the stream and pipe to failAfterError last. 
+        .pipe(eslint.failAfterError());
+});
+
+gulp.task('watch', function() {
+    return watch(sourceFiles, ['lint']);
+});
+
+gulp.task('default', ['lint', 'watch']);

--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ var self = require( "sdk/self" ),
     attached = false,
     statusIcon = require('./lib/toolbar/statusIcon').create(false),
     tabs = require( "sdk/tabs" ),
-    { isUriIncluded } = require('./lib/utils/matchUrl');
+    { isUriIncluded } = require('./lib/utils/matchUrl'),
+    sysEnv = require('./lib/system-env-vars'),
+    curSysEnv = sysEnv();
 
 var jqueryScript = "js/jquery-1.11.3.min.js",
     jqueryObserveScript = "js/jquery-observe.js";
@@ -48,6 +50,7 @@ function onAttach( worker ) {
     */
     worker.on( "message", function( actionObj ) {
 
+        // console.log('onMessage', actionObj);
         if ( actionObj.backslashReplaceRequired ) {
             // special handling required at icon click
             actionObj.url = actionObj.url.replace(/\\/g, '/'); // replace backslashes
@@ -59,11 +62,12 @@ function onAttach( worker ) {
         switch ( actionObj.action ) {
             // Actions from content-script
             case "open":
-                launcher.start( actionObj.url );    
-            break;
+                // check if link contains a window path variable
+                // later add a option to enable env. paths vars?
+                // console.log('checklink', actionObj);
+                var replacedLink = curSysEnv.checkLink(actionObj.url);
 
-            case "reveal":
-                launcher.start( actionObj.url, true);
+                launcher.start(replacedLink, actionObj.reveal);
             break;
         }
 

--- a/index.js
+++ b/index.js
@@ -1,158 +1,158 @@
-var self = require( "sdk/self" ),
-    pageMod = require( "sdk/page-mod" ),
-    array = require( "sdk/util/array" ),
-    launcher = require( "./lib/launch-local-process" ),
-    simplePrefs = require( "sdk/simple-prefs" ),
-    CONST = require( "./lib/common/constants" ),
-    workers = [],
-    attachedCM = false, // Check if context menu is attached.
-    mod = {},
-    attached = false,
-    statusIcon = require('./lib/toolbar/statusIcon').create(false),
-    tabs = require( "sdk/tabs" ),
-    { isUriIncluded } = require('./lib/utils/matchUrl'),
-    sysEnv = require('./lib/system-env-vars'),
-    curSysEnv = sysEnv();
+var self = require('sdk/self'),
+  pageMod = require('sdk/page-mod'),
+  array = require('sdk/util/array'),
+  launcher = require('./lib/launch-local-process'),
+  simplePrefs = require('sdk/simple-prefs'),
+  CONST = require('./lib/common/constants'),
+  workers = [],
+  attachedCM = false, // Check if context menu is attached.
+  mod = {},
+  attached = false,
+  statusIcon = require('./lib/toolbar/statusIcon').create(false),
+  tabs = require('sdk/tabs'),
+  {isUriIncluded} = require('./lib/utils/matchUrl'),
+  sysEnv = require('./lib/system-env-vars'),
+  curSysEnv = sysEnv();
 
-var jqueryScript = "js/jquery-1.11.3.min.js",
-    jqueryObserveScript = "js/jquery-observe.js";
+var jqueryScript = 'js/jquery-1.11.3.min.js',
+  jqueryObserveScript = 'js/jquery-observe.js';
 
-/**
- * Pagemode onAttach handler (communication handling to content script
- * and for launching/opening files)
- */
-function onAttach( worker ) {
+/*
+* Pagemode onAttach handler (communication handling to content script
+* and for launching/opening files)
+*/
+function onAttach(worker) {
 
-    attached = true; // For unit testing to see that the pageMod is attached
+  attached = true; // For unit testing to see that the pageMod is attached
 
-    // statusIcon.changeState(true); // change status icon to active
+  // statusIcon.changeState(true); // change status icon to active
 
-    array.add( workers, worker );
+  array.add(workers, worker);
 
-    if ( !attachedCM ) {
+  if (!attachedCM) {
+    // Add context menu (only if include matches, that's why requiring here)
+    require('./lib/contextMenu')(function(path, reveal) { // Callback
+      launcher.start(path, reveal);
+    });
 
-        // Add context menu (only if include matches, that's why requiring here)
-        require( "./lib/contextMenu" )( function( path, reveal ) { // Callback
-            launcher.start( path, reveal );
-        } );
+    // // add icon to display that we have enabled links on page
+    // statusIcon.changeState(true);
+    attachedCM = true; // Needed because onAttach
+                       // can be executed multiple times
+  }
 
-        // // add icon to display that we have enabled links on page
-        // statusIcon.changeState(true);
-        attachedCM = true; // Needed because onAttach
-                           // can be executed multiple times
+  // Worker events
+  /**
+  * Contentscript message
+  * check action:
+  *   - open: starts windows explorer with a fixed path (no file:// etc)
+  */
+  worker.on('message', function(actionObj) {
+
+    // console.log('onMessage', actionObj);
+    if (actionObj.backslashReplaceRequired) {
+      // special handling required at icon click
+      actionObj.url = actionObj.url.replace(/\\/g, '/'); // replace backslashes
+
+      // we need to check if file has 2 slashes because ff won't fix it
+      actionObj.url = actionObj.url.replace(/file:[\/]{2,3}/i, 'file:\/\/\/');
     }
 
-    // Worker events
-    /**
-    * Contentscript message
-    * check action:
-    *   - open: starts windows explorer with a fixed path (no file:// etc)
-    */
-    worker.on( "message", function( actionObj ) {
+    switch (actionObj.action) {
+    // Actions from content-script
+    case 'open':
+      // check if link contains a window path variable
+      // later add a option to enable env. paths vars?
+      // console.log('checklink', actionObj);
+      var replacedLink = curSysEnv.checkLink(actionObj.url);
 
-        // console.log('onMessage', actionObj);
-        if ( actionObj.backslashReplaceRequired ) {
-            // special handling required at icon click
-            actionObj.url = actionObj.url.replace(/\\/g, '/'); // replace backslashes
+      launcher.start(replacedLink, actionObj.reveal);
+      break;
 
-            // we need to check if file has 2 slashes because ff won't fix it
-            actionObj.url = actionObj.url.replace(/file:[\/]{2,3}/i, 'file:\/\/\/');
-        }
-
-        switch ( actionObj.action ) {
-            // Actions from content-script
-            case "open":
-                // check if link contains a window path variable
-                // later add a option to enable env. paths vars?
-                // console.log('checklink', actionObj);
-                var replacedLink = curSysEnv.checkLink(actionObj.url);
-
-                launcher.start(replacedLink, actionObj.reveal);
-            break;
-        }
-
-    } );
-
-    worker.port.emit( "init", simplePrefs.prefs, CONST );
-
-    // Pageshow / pagehide not needed but we could remove workers if page is hidden
-    // could be useful for context menus. --> not needed here
-    /*Worker.on('pageshow', function() { array.add(workers, this); });
-      worker.on('pagehide', function() { array.remove(workers, this); });
-      */
-
-    // Clean worker if it is detached
-    worker.on( "detach", function() {
-        array.remove( workers, this );
-
-        // remove prefChangeHandlers
-        simplePrefs.removeListener( "enableLinkIcons", onPrefLinkChange );
-        simplePrefs.removeListener( "revealOpenOption", onPrefLinkChange );
-    } );
-
-    function onPrefLinkChange( prefName ) {
-        var newEmitObj = {};
-        newEmitObj[ prefName ] = simplePrefs.prefs[ prefName ];
-
-        // @info: no checks if worker exists needed here because we're
-        //        removing the prefChange Listener with worker detach event.
-        worker.port.emit( "prefChange:" + prefName, newEmitObj );
+    default:
+      // not handled action
+      break;
     }
+  });
 
-    // register simplePref events
-    simplePrefs.on( "enableLinkIcons", onPrefLinkChange );
-    simplePrefs.on( "revealOpenOption", onPrefLinkChange );
+  worker.port.emit('init', simplePrefs.prefs, CONST);
+
+  // Pageshow / pagehide not needed but we could remove workers if page is hidden
+  // could be useful for context menus. --> not needed here
+  /*Worker.on('pageshow', function() { array.add(workers, this); });
+  worker.on('pagehide', function() { array.remove(workers, this); });
+  */
+
+  // Clean worker if it is detached
+  worker.on('detach', function() {
+    array.remove(workers, worker); //this);
+
+    // remove prefChangeHandlers
+    simplePrefs.removeListener('enableLinkIcons', onPrefLinkChange);
+    simplePrefs.removeListener('revealOpenOption', onPrefLinkChange);
+  });
+
+  function onPrefLinkChange(prefName) {
+    var newEmitObj = {};
+
+    newEmitObj[ prefName ] = simplePrefs.prefs[ prefName ];
+
+    // @info: no checks if worker exists needed here because we're
+    //        removing the prefChange Listener with worker detach event.
+    worker.port.emit('prefChange:' + prefName, newEmitObj);
+  }
+
+  // register simplePref events
+  simplePrefs.on('enableLinkIcons', onPrefLinkChange);
+  simplePrefs.on('revealOpenOption', onPrefLinkChange);
 }
 
-/**
- * Creates a new pageMod.
- * Required as a function so we can re-create the pageMod on whitelist preference changes.
- */
+/*
+* Creates a new pageMod.
+* Required as a function so we can re-create the pageMod on whitelist preference changes.
+*/
 function createMod() {
 
-    var whitelist = simplePrefs.prefs.whitelist || "*";
+  var whitelist = simplePrefs.prefs.whitelist || '*';
 
-    mod = pageMod.PageMod( {
-        include: whitelist.split( /\s+/ ),
+  mod = pageMod.PageMod({
+    include: whitelist.split(/\s+/),
+    //AttachTo: 'top', // multiple attachments needed if there are iframes
+    // pageMod can be attached multiple times!!!
+    contentScriptOptions: {
+      enableLinkIcons: simplePrefs.prefs.enableLinkIcons
+    },
+    contentScriptFile: [
+      // Vendor scripts
+      self.data.url(jqueryScript),
 
-        //AttachTo: 'top', // multiple attachments needed if there are iframes
-                           // pageMod can be attached multiple times!!!
-        contentScriptOptions: {
-            enableLinkIcons: simplePrefs.prefs.enableLinkIcons
-        },
-        contentScriptFile: [
+      // jquery plugin
+      self.data.url(jqueryObserveScript),
 
-            // Vendor scripts
-            self.data.url( jqueryScript ),
+      // Custom scripts
+      self.data.url('js/fileLinkAddonContent.js')
+    ],
+    contentStyleFile: [
+      // Custom styles
+      './css/style.css',
 
-            // jquery plugin
-            self.data.url( jqueryObserveScript ),
-
-            // Custom scripts
-            self.data.url( "js/fileLinkAddonContent.js" )
-        ],
-        contentStyleFile: [
-
-            // Custom styles
-            "./css/style.css",
-
-            // Css libs
-            "./css/self-hosted-materialize.css"
-        ],
-        onAttach: onAttach
-    } );
+      // Css libs
+      './css/self-hosted-materialize.css'
+    ],
+    onAttach: onAttach
+  });
 }
 
-/**
- * Tab event handler for status icon
- * state = true --> green icon = links active in current tab
- * state = false --> red icon = links active in current tab
- */
+/*
+* Tab event handler for status icon
+* state = true --> green icon = links active in current tab
+* state = false --> red icon = links active in current tab
+*/
 function checkStatus() {
-    // if uri matches include change state to true
-    // console.log('checkStatus: ', tabs.activeTab.url, mod.include);
-    statusIcon.changeState(isUriIncluded(mod.include,
-        tabs.activeTab.url));
+// if uri matches include change state to true
+// console.log('checkStatus: ', tabs.activeTab.url, mod.include);
+  statusIcon.changeState(isUriIncluded(mod.include,
+    tabs.activeTab.url));
 }
 
 // register event handlers for statusIcon
@@ -160,23 +160,23 @@ tabs.on('activate', checkStatus);
 tabs.on('pageshow', checkStatus);
 
 function main() {
-    createMod(); //First init
+  createMod(); //First init
 
-    function onWhitelistChange( prefName ) {
-        // mod.include = prefs.options[prefName].split( /\s+/ ); // update incl.
-        // updating would be OK but pageMod keeps active after removal from wl.
-        mod.destroy();
-        createMod();
-    }
+  function onWhitelistChange(/* prefName */) {
+    // mod.include = prefs.options[prefName].split(/\s+/); // update incl.
+    // updating would be OK but pageMod keeps active after removal from wl.
+    mod.destroy();
+    createMod();
+  }
 
-    simplePrefs.on( "whitelist", onWhitelistChange );
+  simplePrefs.on('whitelist', onWhitelistChange);
 }
 
-//tabs.open( "http://jsfiddle.net/awolf2904/tefcs74q/" ); // Debugging tab
-//tabs.open( "127.0.0.1:3000" ); // Debugging tab
+//tabs.open('http://jsfiddle.net/awolf2904/tefcs74q/'); // Debugging tab
+//tabs.open('127.0.0.1:3000'); // Debugging tab
 
 function getAttached() {
-    return attached;
+  return attached;
 }
 
 exports.isAttached = getAttached;

--- a/index.js
+++ b/index.js
@@ -1,21 +1,21 @@
 var self = require('sdk/self'),
-  pageMod = require('sdk/page-mod'),
-  array = require('sdk/util/array'),
-  launcher = require('./lib/launch-local-process'),
-  simplePrefs = require('sdk/simple-prefs'),
-  CONST = require('./lib/common/constants'),
-  workers = [],
-  attachedCM = false, // Check if context menu is attached.
-  mod = {},
-  attached = false,
-  statusIcon = require('./lib/toolbar/statusIcon').create(false),
-  tabs = require('sdk/tabs'),
-  {isUriIncluded} = require('./lib/utils/matchUrl'),
-  sysEnv = require('./lib/system-env-vars'),
-  curSysEnv = sysEnv();
+    pageMod = require('sdk/page-mod'),
+    array = require('sdk/util/array'),
+    launcher = require('./lib/launch-local-process'),
+    simplePrefs = require('sdk/simple-prefs'),
+    CONST = require('./lib/common/constants'),
+    workers = [],
+    attachedCM = false, // Check if context menu is attached.
+    mod = {},
+    attached = false,
+    statusIcon = require('./lib/toolbar/statusIcon').create(false),
+    tabs = require('sdk/tabs'),
+    {isUriIncluded} = require('./lib/utils/matchUrl'),
+    sysEnv = require('./lib/system-env-vars'),
+    curSysEnv = sysEnv();
 
 var jqueryScript = 'js/jquery-1.11.3.min.js',
-  jqueryObserveScript = 'js/jquery-observe.js';
+    jqueryObserveScript = 'js/jquery-observe.js';
 
 /*
 * Pagemode onAttach handler (communication handling to content script
@@ -23,124 +23,127 @@ var jqueryScript = 'js/jquery-1.11.3.min.js',
 */
 function onAttach(worker) {
 
-  attached = true; // For unit testing to see that the pageMod is attached
+    attached = true; // For unit testing to see that the pageMod is attached
 
-  // statusIcon.changeState(true); // change status icon to active
+    // statusIcon.changeState(true); // change status icon to active
 
-  array.add(workers, worker);
+    array.add(workers, worker);
 
-  if (!attachedCM) {
-    // Add context menu (only if include matches, that's why requiring here)
-    require('./lib/contextMenu')(function(path, reveal) { // Callback
-      launcher.start(path, reveal);
+    if (!attachedCM) {
+        // Add context menu (only if include matches, that's why requiring here)
+        require('./lib/contextMenu')(function(path, reveal) { // Callback
+            launcher.start(path, reveal);
+        });
+
+        // // add icon to display that we have enabled links on page
+        // statusIcon.changeState(true);
+        attachedCM = true; // Needed because onAttach
+        // can be executed multiple times
+    }
+
+    // Worker events
+    /**
+    * Contentscript message
+    * check action:
+    *   - open: starts windows explorer with a fixed path (no file:// etc)
+    */
+    worker.on('message', function(actionObj) {
+
+        // console.log('onMessage', actionObj);
+        if (actionObj.backslashReplaceRequired) {
+            // special handling required at icon click
+            actionObj.url = actionObj.
+                url.replace(/\\/g, '/'); // replace backslashes
+
+            // we need to check if file has 2 slashes because ff won't fix it
+            actionObj.url = actionObj.
+                url.replace(/file:[\/]{2,3}/i, 'file:\/\/\/');
+        }
+
+        switch (actionObj.action) {
+        // Actions from content-script
+        case 'open':
+            // check if link contains a window path variable
+            // later add a option to enable env. paths vars?
+            // console.log('checklink', actionObj);
+            var replacedLink = curSysEnv.checkLink(actionObj.url);
+
+            launcher.start(replacedLink, actionObj.reveal);
+            break;
+
+        default:
+            // not handled action
+            break;
+        }
     });
 
-    // // add icon to display that we have enabled links on page
-    // statusIcon.changeState(true);
-    attachedCM = true; // Needed because onAttach
-                       // can be executed multiple times
-  }
+    worker.port.emit('init', simplePrefs.prefs, CONST);
 
-  // Worker events
-  /**
-  * Contentscript message
-  * check action:
-  *   - open: starts windows explorer with a fixed path (no file:// etc)
-  */
-  worker.on('message', function(actionObj) {
+    // Pageshow / pagehide not needed but we could remove workers if page is
+    // hidden could be useful for context menus. --> not needed here
+    /*Worker.on('pageshow', function() { array.add(workers, this); });
+    worker.on('pagehide', function() { array.remove(workers, this); });
+    */
 
-    // console.log('onMessage', actionObj);
-    if (actionObj.backslashReplaceRequired) {
-      // special handling required at icon click
-      actionObj.url = actionObj.url.replace(/\\/g, '/'); // replace backslashes
+    // Clean worker if it is detached
+    worker.on('detach', function() {
+        array.remove(workers, worker); //this);
 
-      // we need to check if file has 2 slashes because ff won't fix it
-      actionObj.url = actionObj.url.replace(/file:[\/]{2,3}/i, 'file:\/\/\/');
+        // remove prefChangeHandlers
+        simplePrefs.removeListener('enableLinkIcons', onPrefLinkChange);
+        simplePrefs.removeListener('revealOpenOption', onPrefLinkChange);
+    });
+
+    function onPrefLinkChange(prefName) {
+        var newEmitObj = {};
+
+        newEmitObj[ prefName ] = simplePrefs.prefs[ prefName ];
+
+        // @info: no checks if worker exists needed here because we're
+        //        removing the prefChange Listener with worker detach event.
+        worker.port.emit('prefChange:' + prefName, newEmitObj);
     }
 
-    switch (actionObj.action) {
-    // Actions from content-script
-    case 'open':
-      // check if link contains a window path variable
-      // later add a option to enable env. paths vars?
-      // console.log('checklink', actionObj);
-      var replacedLink = curSysEnv.checkLink(actionObj.url);
-
-      launcher.start(replacedLink, actionObj.reveal);
-      break;
-
-    default:
-      // not handled action
-      break;
-    }
-  });
-
-  worker.port.emit('init', simplePrefs.prefs, CONST);
-
-  // Pageshow / pagehide not needed but we could remove workers if page is hidden
-  // could be useful for context menus. --> not needed here
-  /*Worker.on('pageshow', function() { array.add(workers, this); });
-  worker.on('pagehide', function() { array.remove(workers, this); });
-  */
-
-  // Clean worker if it is detached
-  worker.on('detach', function() {
-    array.remove(workers, worker); //this);
-
-    // remove prefChangeHandlers
-    simplePrefs.removeListener('enableLinkIcons', onPrefLinkChange);
-    simplePrefs.removeListener('revealOpenOption', onPrefLinkChange);
-  });
-
-  function onPrefLinkChange(prefName) {
-    var newEmitObj = {};
-
-    newEmitObj[ prefName ] = simplePrefs.prefs[ prefName ];
-
-    // @info: no checks if worker exists needed here because we're
-    //        removing the prefChange Listener with worker detach event.
-    worker.port.emit('prefChange:' + prefName, newEmitObj);
-  }
-
-  // register simplePref events
-  simplePrefs.on('enableLinkIcons', onPrefLinkChange);
-  simplePrefs.on('revealOpenOption', onPrefLinkChange);
+    // register simplePref events
+    simplePrefs.on('enableLinkIcons', onPrefLinkChange);
+    simplePrefs.on('revealOpenOption', onPrefLinkChange);
 }
 
 /*
 * Creates a new pageMod.
-* Required as a function so we can re-create the pageMod on whitelist preference changes.
+* Required as a function so we can re-create the pageMod on whitelist
+* preference changes.
 */
 function createMod() {
 
-  var whitelist = simplePrefs.prefs.whitelist || '*';
+    var whitelist = simplePrefs.prefs.whitelist || '*';
 
-  mod = pageMod.PageMod({
-    include: whitelist.split(/\s+/),
-    //AttachTo: 'top', // multiple attachments needed if there are iframes
-    // pageMod can be attached multiple times!!!
-    contentScriptOptions: {
-      enableLinkIcons: simplePrefs.prefs.enableLinkIcons
-    },
-    contentScriptFile: [
-      // Vendor scripts
-      self.data.url(jqueryScript),
+    mod = pageMod.PageMod({
+        include: whitelist.split(/\s+/),
+        //AttachTo: 'top', // multiple attachments needed if there are iframes
+        // pageMod can be attached multiple times!!!
+        contentScriptOptions: {
+            enableLinkIcons: simplePrefs.prefs.enableLinkIcons
+        },
+        contentScriptFile: [
+            // Vendor scripts
+            self.data.url(jqueryScript),
 
-      // jquery plugin
-      self.data.url(jqueryObserveScript),
+            // jquery plugin
+            self.data.url(jqueryObserveScript),
 
-      // Custom scripts
-      self.data.url('js/fileLinkAddonContent.js')
-    ],
-    contentStyleFile: [
-      // Custom styles
-      './css/style.css',
+            // Custom scripts
+            self.data.url('js/fileLinkAddonContent.js')
+        ],
+        contentStyleFile: [
+            // Custom styles
+            './css/style.css',
 
-      // Css libs
-      './css/self-hosted-materialize.css'
-    ],
-    onAttach: onAttach
-  });
+            // Css libs
+            './css/self-hosted-materialize.css'
+        ],
+        onAttach: onAttach
+    });
 }
 
 /*
@@ -149,10 +152,10 @@ function createMod() {
 * state = false --> red icon = links active in current tab
 */
 function checkStatus() {
-// if uri matches include change state to true
-// console.log('checkStatus: ', tabs.activeTab.url, mod.include);
-  statusIcon.changeState(isUriIncluded(mod.include,
-    tabs.activeTab.url));
+    // if uri matches include change state to true
+    // console.log('checkStatus: ', tabs.activeTab.url, mod.include);
+    statusIcon.changeState(isUriIncluded(mod.include,
+        tabs.activeTab.url));
 }
 
 // register event handlers for statusIcon
@@ -160,23 +163,24 @@ tabs.on('activate', checkStatus);
 tabs.on('pageshow', checkStatus);
 
 function main() {
-  createMod(); //First init
+    createMod(); //First init
 
-  function onWhitelistChange(/* prefName */) {
-    // mod.include = prefs.options[prefName].split(/\s+/); // update incl.
-    // updating would be OK but pageMod keeps active after removal from wl.
-    mod.destroy();
-    createMod();
-  }
+    function onWhitelistChange(/* prefName */) {
+        // mod.include = prefs.options[prefName].split(/\s+/);
+        // updating would be OK but pageMod keeps active
+        // after removal from wl.
+        mod.destroy();
+        createMod();
+    }
 
-  simplePrefs.on('whitelist', onWhitelistChange);
+    simplePrefs.on('whitelist', onWhitelistChange);
 }
 
 //tabs.open('http://jsfiddle.net/awolf2904/tefcs74q/'); // Debugging tab
 //tabs.open('127.0.0.1:3000'); // Debugging tab
 
 function getAttached() {
-  return attached;
+    return attached;
 }
 
 exports.isAttached = getAttached;

--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -1,7 +1,7 @@
 // Constants.js
-var pkg = require( "../../package.json" ),
-    osFileManagerName = require( "../utils/os-util" ).getFileManagerDisplayName,
-    _ = require("sdk/l10n").get;
+var pkg = require('../../package.json'),
+    osFileManagerName = require('../utils/os-util').getFileManagerDisplayName,
+    _ = require('sdk/l10n').get;
 
 exports.APP = {
     name: pkg.name,

--- a/lib/contextMenu.js
+++ b/lib/contextMenu.js
@@ -5,69 +5,69 @@
 // - execute selected file link
 // (two cases selected text and right click on link --> two menus)
 
-var contextMenu = require( "sdk/context-menu" ),
-    _ = require("sdk/l10n").get
+var contextMenu = require('sdk/context-menu'),
+    _ = require('sdk/l10n').get;
 
-/**
+/*
  * Creates two context submenus for different use cases (with open and reveal):
  * 1. if user selected a link text file://...
  * 2. if the user right clicks at a file link
  *
  * @param callback(path, reveal) reveal = true --> reveals folder
  */
-module.exports = function( callback ) {
-    var selectContentScript = 'self.on("click", function () {' +
-        "  var text = window.getSelection().toString();" +
-        "  self.postMessage(text);" +
-        "});"; // Could be refactored to a separate file later --> improve readability
+module.exports = function(callback) {
+    var selectContentScript = 'self.on(\'click\', function () {' +
+        '  var text = window.getSelection().toString();' +
+        '  self.postMessage(text);' +
+        '});'; // Could be refactored to a separate file later --> improve readability
 
-    var menuItemSelect = contextMenu.Item( {
+    var menuItemSelect = contextMenu.Item({
         label: _('LABEL_CONTEXT_MENU_OPEN_LINK'),
         contentScript: selectContentScript,
 
-        //AccessKey: "l",
-        onMessage: function( url ) {
-            callback( url );
+        //AccessKey: 'l',
+        onMessage: function(url) {
+            callback(url);
         }
-    } );
+    });
 
-    var menuItemSelectReveal = contextMenu.Item( {
+    var menuItemSelectReveal = contextMenu.Item({
         label: _('LABEL_CONTEXT_MENU_OPEN_CONTAINING'),
         contentScript: selectContentScript,
 
-        //AccessKey: "l",
-        onMessage: function( url ) {
-            callback( url, true );
+        //AccessKey: 'l',
+        onMessage: function(url) {
+            callback(url, true);
         }
-    } );
+    });
 
-    var itemContentScript = 'self.on("click", function (node , data) {' +
-        "  self.postMessage(node.href);" +
-        "});";
+    var itemContentScript = 'self.on(\'click\', function (node , data) {' +
+        '  self.postMessage(node.href);' +
+        '});';
 
-    var menuItemFolder = contextMenu.Item( {
+    var menuItemFolder = contextMenu.Item({
         label: _('LABEL_CONTEXT_MENU_OPEN_CONTAINING'),
         contentScript: itemContentScript,
 
-        //AccessKey: "l",
-        onMessage: function( url ) {
+        //AccessKey: 'l',
+        onMessage: function(url) {
 
             //Console.log(url);
-            callback( url, true );
+            callback(url, true);
         }
-    } );
+    });
 
-    var menuItemLink = contextMenu.Item( {
+    var menuItemLink = contextMenu.Item({
         label: _('LABEL_CONTEXT_MENU_OPEN_LINK'),
         contentScript: itemContentScript,
 
-        //AccessKey: "l",
-        onMessage: function( url ) {
+        //AccessKey: 'l',
+        onMessage: function(url) {
 
             //Console.log(url);
-            callback( url, false );
+            callback(url, false);
         }
-    } );
+    });
 
     // create a submenu for selection
     contextMenu.Menu({
@@ -82,7 +82,7 @@ module.exports = function( callback ) {
     // create a submenu for right click on link
     contextMenu.Menu({
         label: _('LABEL_CONTEXT_SUB_LINK_TITLE'),
-        context: contextMenu.SelectorContext( "a[href]" ),
+        context: contextMenu.SelectorContext('a[href]'),
         items: [
             menuItemLink,
             menuItemFolder

--- a/lib/contextMenu.js
+++ b/lib/contextMenu.js
@@ -70,7 +70,7 @@ module.exports = function( callback ) {
     } );
 
     // create a submenu for selection
-    var subMenuSelection = contextMenu.Menu({
+    contextMenu.Menu({
         label: _('LABEL_CONTEXT_SUB_SELECTION_TITLE'),
         context: contextMenu.SelectionContext(),
         items: [
@@ -80,7 +80,7 @@ module.exports = function( callback ) {
     });
 
     // create a submenu for right click on link
-    var subMenuRightClick = contextMenu.Menu({
+    contextMenu.Menu({
         label: _('LABEL_CONTEXT_SUB_LINK_TITLE'),
         context: contextMenu.SelectorContext( "a[href]" ),
         items: [

--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -108,7 +108,7 @@ function getNsIFileFromPath ( path ) {
         nsiFile = new FileUtils.File( localPath );
     }
     catch(e) {
-        console.log('file error', e);
+        //console.log('file error', e);
         nsiFile = null;
     }
 
@@ -136,6 +136,7 @@ function start( path, reveal ) {
     // --> preference to enable backslash links not possible because we can't
     //     test for backslashes here
 
+    // console.log('opening path', path);
     var nsLocalFile = getNsIFileFromPath( path );
 
 
@@ -144,7 +145,9 @@ function start( path, reveal ) {
         if ( reveal ) {
             nsLocalFile.reveal();
         } else {
-            if ( nsLocalFile.isExecutable() && !allowAll ) {
+            if ( nsLocalFile.isExecutable() && !allowAll &&
+                !nsLocalFile.isDirectory() ) {
+                //console.log('is isExecutable', nsLocalFile, path, nsLocalFile.path);
                 notification.show( CONST.APP.name,
                     _('ERROR_EXECTUBALES_NOT_ENABLED'));
             } else {
@@ -190,8 +193,16 @@ function start( path, reveal ) {
             // better check the settings on pageMod attach
             notification.show( CONST.APP.name, _('INFO_CONFIG_CHANGE_SMB'));
         } else {
-            notification.show( CONST.APP.name, 
+            try {
+                // e.g. clicking on a link with %HOMEDRIVE%%HOMEPATH%
+                // in Linux will throw malformed URI sequence
+                notification.show( CONST.APP.name, 
                 _('ERROR_BAD_LINK', decodeURI(path)) );
+            }
+            catch(e) {
+                notification.show( CONST.APP.name, 
+                _('ERROR_BAD_LINK', ' - ' + e.message));
+            }
         }
     }
 }

--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -1,11 +1,11 @@
 // LaunchExplorer.js
-var { Cc, Ci, Cu } = require( "chrome" ), // Use Components.classes & Components.interfaces
-    linkUtil = require( "./utils/link-util" ),
-    notification = require( "./notification" ),
-    CONST = require( "./common/constants" ),
-    simplePrefs = require( "sdk/simple-prefs" ),
-    FileUtils = Cu.import("resource://gre/modules/FileUtils.jsm").FileUtils,
-    _ = require("sdk/l10n").get,
+var {Cc, Ci, Cu} = require('chrome'), // Use Components.classes & Components.interfaces
+    linkUtil = require('./utils/link-util'),
+    notification = require('./notification'),
+    CONST = require('./common/constants'),
+    simplePrefs = require('sdk/simple-prefs'),
+    FileUtils = Cu.import('resource://gre/modules/FileUtils.jsm').FileUtils,
+    _ = require('sdk/l10n').get,
     openSmbLink = false; // true if we have a smb link to open
 
 //
@@ -14,77 +14,87 @@ var { Cc, Ci, Cu } = require( "chrome" ), // Use Components.classes & Components
 // SEE https://developer.mozilla.org/en/XPCOM_Interface_Reference/nsIEnvironment
 //
 
-function getEnvironmentVariable( variableName ) {
-    var env = Cc[ "@mozilla.org/process/environment;1" ].getService( Ci.nsIEnvironment );
-    if ( !env.exists( variableName ) ) {
-        throw "getEnvironmentVariable: variable does not exist: " + variableName;
+function getEnvironmentVariable(variableName) {
+    var env = Cc['@mozilla.org/process/environment;1'].
+        getService(Ci.nsIEnvironment);
+
+    if (!env.exists(variableName)) {
+        throw 'getEnvironmentVariable: variable does not exist: ' +
+        variableName;
     } else {
-        return env.get( variableName );
+        return env.get(variableName);
     }
 }
 
 exports.getEnvironmentVariable = getEnvironmentVariable;
 
 // url2path from here
-// http://sources.disruptive-innovations.com/bluegriffon/trunk/modules/urlHelper.jsm
+// sources.disruptive-innovations.com/bluegriffon/trunk/modules/urlHelper.jsm
 function url2path(url) {
     var path = url;
 
     if (/^file/i.test(url)) {
         try {
-          var uri = Cc['@mozilla.org/network/standard-url;1']
-                              .createInstance(Ci.nsIURL);
-          var file = Cc['@mozilla.org/file/local;1']
-                               .createInstance(Ci.nsILocalFile);
+            var uri = Cc['@mozilla.org/network/standard-url;1'].
+                createInstance(Ci.nsIURL);
+            var file = Cc['@mozilla.org/file/local;1'].
+                createInstance(Ci.nsILocalFile);
+            // console.log('before replace', url);
+            // add feature to allow 4 slashes too for UNC network addresses
+            var regex = /\bfile:(\/\/){2}\b/i;
 
-          // console.log('before replace', url);
-          // add feature to allow 4 slashes too for UNC network addresses
-          var regex = /\bfile:(\/\/){2}\b/i;
-          url = url.replace(regex,
-           'file://///'); //4 slashes? add another one to have 5 slashes
-          // console.log('replaced', url);
-          uri.spec = url;
+            //4 slashes? add another one to have 5 slashes
+            url = url.replace(regex, 'file://///');
+            // console.log('replaced', url);
+            uri.spec = url;
 
-          try { // decent OS
-            var unixPath = uri.path;
+            try { // decent OS
+                var unixPath = uri.path;
 
-            // replace backslashes (just if there are any)
-            // windows can open file:\\ but Linux can't
-            // console.log('test unixPath', /\%5C/.test(unixPath), unixPath);
-            if ( /\%5C/.test(unixPath) ) {
-              // contains backslashes --> replace with slashes
-              // @todo the following log is only visible to addon developer
-              //       (also the log is only visible in unix systems, check why)
-              //       --> It would be better to have it in browser console
-              //           but this requires some work. (see PR #58)
-              console.log('Handling non-standard backslash links now.');
-              unixPath = unixPath.replace(/\%5C/g, "/"); // converted %5c = \ backslashes to slashes
-              unixPath = unixPath.replace(/\/{3}/, "");  // remove 3 slashes added by FF
-              //console.log('fixed path', unixPath);
+                // replace backslashes (just if there are any)
+                // windows can open file:\\ but Linux can't
+                // console.log('test unixPath', /\%5C/.test(unixPath),
+                //  unixPath);
+                if (/\%5C/.test(unixPath)) {
+                    // contains backslashes --> replace with slashes
+                    // @todo the following log is only visible to addon
+                    //       developer
+                    //       (also the log is only visible in unix systems,
+                    //       check why)
+                    //       --> It would be better to have it in browser
+                    //           console
+                    //           but this requires some work. (see PR #58)
+                    console.log('Handling non-standard backslash ' +
+                        'links now.');
+                    // converted %5c = \ backslashes to slashes
+                    unixPath = unixPath.replace(/\%5C/g, '/');
+                    // remove 3 slashes added by FF
+                    unixPath = unixPath.replace(/\/{3}/, '');
+                    //console.log('fixed path', unixPath);
+                }
+
+                // hack to have ~ path working in Linux
+                // one or two slashes before ~ // stop at first / after ~
+                unixPath = unixPath.replace(/(\/){1,2}~\//, '~/');
+
+                file.initWithPath(unixPath);
+            } catch (e) {
+                // @todo check if we need a better handling later
+                console.log(e);
             }
-
-            // hack to have ~ path working in Linux
-            unixPath = unixPath.replace(/(\/){1,2}~\//, "~/"); // one or two slashes before ~ // stop at first / after ~
-
-            file.initWithPath(unixPath);
-          } 
-          catch (e) {
-            console.log(e); //@todo check if we need a better handling later
-          }
-          try { // Windows sucks
-            //   console.log('windows', uri.path, path);
-            file.initWithPath(uri.path.replace(/^\//,"").replace(/\//g,"\\"));
-          } 
-          catch (e) {
-            console.log(e);
-          } 
-          path = decodeURI(file.path);
-        } 
-        catch(e) {
+            try { // Windows sucks
+                //   console.log('windows', uri.path, path);
+                file.initWithPath(uri.path.replace(/^\//,'').
+                    replace(/\//g,'\\'));
+            } catch (e) {
+                console.log(e);
+            }
+            path = decodeURI(file.path);
+        } catch(e) {
             console.log(e);
         }
     }
-    /*else if ( /^(smb|afp)/i.test(path) ) {
+        /*else if (/^(smb|afp)/i.test(path)) {
         console.log('smb/afp link');
         // how do we need to handle these links so nsiFile can open them?!
 
@@ -97,64 +107,63 @@ function url2path(url) {
 
 exports.url2path = url2path;
 
-function getNsIFileFromPath ( path ) {
-    var localPath = linkUtil.stripQuotes( path ),
+function getNsIFileFromPath(path) {
+    var localPath = linkUtil.stripQuotes(path),
         nsiFile;
 
-    // we need this because the nsILocalFile seems not happy with file:/// on Windows
-    // (but Windows explorer would be)
+    // we need this because the nsILocalFile seems not happy with file:///
+    // on Windows (but Windows explorer would be)
 
-    localPath = url2path(localPath); //linkUtil.osSpecificLinkStringFix( localPath );
+    localPath = url2path(localPath);
     // console.log('localpath', localPath);
 
     // the following code works except smb/afp
 
     try {
         // is doing the same as the code before (nsILocalFile), just a wrapper.
-        nsiFile = new FileUtils.File( localPath );
-    }
-    catch(e) {
+        nsiFile = new FileUtils.File(localPath);
+    } catch(e) {
         //console.log('file error', e);
         nsiFile = null;
     }
 
-    return nsiFile//nsLocalFile;
+    return nsiFile;
 }
 
 exports.getNsIFileFromPath = getNsIFileFromPath;
 
 
-function pathExists( localFile ) {
-    //let localFile = getNsIFileFromPath( localPath );
-
+function pathExists(localFile) {
+    //let localFile = getNsIFileFromPath(localPath);
     return localFile && localFile.exists();
 }
 
 exports.pathExists = pathExists;
 
-function start( path, reveal ) {
+function start(path, reveal) {
     var fileRegex = /^(.*\/)([^\/]*)$/,
         allowAll = simplePrefs.prefs.enableExecutables;
-        
+
     //console.log('test if backslash in path', /\\/.test(path), path);
-    //if ( /\\/.test(path) ) {
+    //if (/\\/.test(path)) {
     // test not working because FF converts \ to /
     // --> preference to enable backslash links not possible because we can't
     //     test for backslashes here
 
     // console.log('opening path', path);
-    var nsLocalFile = getNsIFileFromPath( path );
+    var nsLocalFile = getNsIFileFromPath(path);
 
 
-    if ( pathExists( nsLocalFile ) ) {
+    if (pathExists(nsLocalFile)) {
         // console.log('path exists', nsLocalFile);
-        if ( reveal ) {
+        if (reveal) {
             nsLocalFile.reveal();
         } else {
-            if ( nsLocalFile.isExecutable() && !allowAll &&
-                !nsLocalFile.isDirectory() ) {
-                //console.log('is isExecutable', nsLocalFile, path, nsLocalFile.path);
-                notification.show( CONST.APP.name,
+            if (nsLocalFile.isExecutable() && !allowAll &&
+            !nsLocalFile.isDirectory()) {
+                //console.log('is isExecutable', nsLocalFile, path,
+                //  nsLocalFile.path);
+                notification.show(CONST.APP.name,
                     _('ERROR_EXECTUBALES_NOT_ENABLED'));
             } else {
                 nsLocalFile.launch();
@@ -162,12 +171,13 @@ function start( path, reveal ) {
         }
     } else {
         // file could be not found --> check if a reveal is requested
-        if ( reveal ) {
+        if (reveal) {
             //console.log('Reveal', path);
             // already fixed before calling start!!
             //path = path.replace(/\\/g, '/'); // replace backslashes
 
-            // we need to check if file has 2 slashes because ff won't fix it
+            // we need to check if file has 2 slashes
+            // because ff won't fix it
             //path = path.replace(/file:[\/]{2,3}/i, 'file:\/\/\/');
 
             // problem exec crashes if there is a backslash passed!!
@@ -175,39 +185,37 @@ function start( path, reveal ) {
 
             // --> happens if selection reveal marked e.g. C:\temp\test.text
 
-            // if reveal omit the file so we're getting the folder even with a
-            // non-existing file
+            // if reveal omit the file so we're getting the folder
+            // even with a non-existing file
             path = fileRegex.exec(path)[1]; // strip file
 
-            if ( ! /file:/i.test(path) ) {
+            if (! /file:/i.test(path)) {
                 // selected a link with-out file:// for reveal
                 path = 'file:///' + path; // add file protocol
             }
-            nsLocalFile = getNsIFileFromPath( path );
+            nsLocalFile = getNsIFileFromPath(path);
 
             // test again
-            if ( pathExists( nsLocalFile ) ) {
+            if (pathExists(nsLocalFile)) {
                 nsLocalFile.reveal();
+            } else {
+                notification.show(CONST.APP.name,
+                    _('ERROR_BAD_LINK', decodeURI(path)));
             }
-            else {
-                notification.show( CONST.APP.name, 
-                    _('ERROR_BAD_LINK', decodeURI(path)) );
-            }
-        }
-        else if ( openSmbLink ) { // add os-check later
-            // check configuration and modify it if necessary.
-            // better check the settings on pageMod attach
-            notification.show( CONST.APP.name, _('INFO_CONFIG_CHANGE_SMB'));
+        } else if (openSmbLink) { // add os-check later
+                // check configuration and modify it if necessary.
+                // better check the settings on pageMod attach
+            notification.show(CONST.APP.name,
+                _('INFO_CONFIG_CHANGE_SMB'));
         } else {
             try {
                 // e.g. clicking on a link with %HOMEDRIVE%%HOMEPATH%
                 // in Linux will throw malformed URI sequence
-                notification.show( CONST.APP.name, 
-                _('ERROR_BAD_LINK', decodeURI(path)) );
-            }
-            catch(e) {
-                notification.show( CONST.APP.name, 
-                _('ERROR_BAD_LINK', ' - ' + e.message));
+                notification.show(CONST.APP.name,
+                    _('ERROR_BAD_LINK', decodeURI(path)));
+            } catch(e) {
+                notification.show(CONST.APP.name,
+                    _('ERROR_BAD_LINK', ' - ' + e.message));
             }
         }
     }

--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -4,8 +4,6 @@ var { Cc, Ci, Cu } = require( "chrome" ), // Use Components.classes & Components
     notification = require( "./notification" ),
     CONST = require( "./common/constants" ),
     simplePrefs = require( "sdk/simple-prefs" ),
-    {isWindowsOs} = require( "./utils/os-util"),
-
     FileUtils = Cu.import("resource://gre/modules/FileUtils.jsm").FileUtils,
     _ = require("sdk/l10n").get,
     openSmbLink = false; // true if we have a smb link to open
@@ -23,7 +21,7 @@ function getEnvironmentVariable( variableName ) {
     } else {
         return env.get( variableName );
     }
-};
+}
 
 exports.getEnvironmentVariable = getEnvironmentVariable;
 
@@ -69,13 +67,21 @@ function url2path(url) {
             unixPath = unixPath.replace(/(\/){1,2}~\//, "~/"); // one or two slashes before ~ // stop at first / after ~
 
             file.initWithPath(unixPath);
-          } catch (e) {}
+          } 
+          catch (e) {
+            console.log(e); //@todo check if we need a better handling later
+          }
           try { // Windows sucks
             //   console.log('windows', uri.path, path);
             file.initWithPath(uri.path.replace(/^\//,"").replace(/\//g,"\\"));
-          } catch (e) {}
+          } 
+          catch (e) {
+            console.log(e);
+          } 
           path = decodeURI(file.path);
-        } catch(e) {
+        } 
+        catch(e) {
+            console.log(e);
         }
     }
     /*else if ( /^(smb|afp)/i.test(path) ) {
@@ -93,7 +99,7 @@ exports.url2path = url2path;
 
 function getNsIFileFromPath ( path ) {
     var localPath = linkUtil.stripQuotes( path ),
-        nsLocalFile, nsiFile;
+        nsiFile;
 
     // we need this because the nsILocalFile seems not happy with file:/// on Windows
     // (but Windows explorer would be)
@@ -113,7 +119,7 @@ function getNsIFileFromPath ( path ) {
     }
 
     return nsiFile//nsLocalFile;
-};
+}
 
 exports.getNsIFileFromPath = getNsIFileFromPath;
 

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -1,14 +1,14 @@
 // Notifications.js
-var notifications = require( "sdk/notifications" );
+var notifications = require('sdk/notifications');
 
-/**
+/*
  * Show notification
  * @param {string} Title of the notifcation
  * @param {string} Text of the message
  */
-exports.show = function( title, text ) {
-    notifications.notify( {
+exports.show = function(title, text) {
+    notifications.notify({
         title: title,
         text: text
-    } );
+    });
 };

--- a/lib/system-env-vars.js
+++ b/lib/system-env-vars.js
@@ -1,11 +1,11 @@
 // system-env-vars.js
-// check if link contains a path variable and 
+// check if link contains a path variable and
 // add the real path into link to open into
 // Windows style %name%
 // Linux style $name$
-const { env } = require('sdk/system/environment');
+const {env} = require('sdk/system/environment');
 
-const {isWindowsOs} = require( './utils/os-util' );
+const {isWindowsOs} = require('./utils/os-util');
 
 module.exports = function sysEnv() {
     // required test
@@ -14,8 +14,8 @@ module.exports = function sysEnv() {
     // - Replace every occurence of a variable in the link
 
     // regex to match %var_name% but not e.g. %20 encoding
-    var _currentEnvRegex = isWindowsOs() ? 
-        /\%(?!\d{2})\w+\%/g:
+    var _currentEnvRegex = isWindowsOs() ?
+        /\%(?!\d{2})\w+\%/g :
         /\$(?!\d{2})\w+\$/g;
 
     return {
@@ -26,10 +26,10 @@ module.exports = function sysEnv() {
             // console.log('checkLink', _currentEnvRegex, pathVars, url);
 
             if (pathVars !== null) {
-                for(var i=0; i < pathVars.length; i++) {
+                for(var i = 0; i < pathVars.length; i++) {
                     pathKey = pathVars[i].replace(/(\%|\$)/g, ''); // remove % or $
                     //console.log(pathKey, env[pathKey], env);
-                    url = url.replace(new RegExp(_currentEnvRegex.source), 
+                    url = url.replace(new RegExp(_currentEnvRegex.source),
                         env[pathKey] || ''); /// undefined will be changed to ''
 
                     url = url.replace(/\\/g, '\/'); // replace backslashes
@@ -38,5 +38,5 @@ module.exports = function sysEnv() {
             }
             return url;
         }
-    }
-}
+    };
+};

--- a/lib/system-env-vars.js
+++ b/lib/system-env-vars.js
@@ -1,0 +1,42 @@
+// system-env-vars.js
+// check if link contains a path variable and 
+// add the real path into link to open into
+// Windows style %name%
+// Linux style $name$
+const { env } = require('sdk/system/environment');
+
+const {isWindowsOs} = require( './utils/os-util' );
+
+module.exports = function sysEnv() {
+    // required test
+    // - multiple path variables possible in link
+    // - How is it displayed in tooltip/statusbar?
+    // - Replace every occurence of a variable in the link
+
+    // regex to match %var_name% but not e.g. %20 encoding
+    var _currentEnvRegex = isWindowsOs() ? 
+        /\%(?!\d{2})\w+\%/g:
+        /\$(?!\d{2})\w+\$/g;
+
+    return {
+        checkLink: function(url) {
+            // %name% already removed --> Check where it is removed
+            var pathVars = url.match(_currentEnvRegex),
+                pathKey; // single path variable
+            // console.log('checkLink', _currentEnvRegex, pathVars, url);
+
+            if (pathVars !== null) {
+                for(var i=0; i < pathVars.length; i++) {
+                    pathKey = pathVars[i].replace(/(\%|\$)/g, ''); // remove % or $
+                    //console.log(pathKey, env[pathKey], env);
+                    url = url.replace(new RegExp(_currentEnvRegex.source), 
+                        env[pathKey] || ''); /// undefined will be changed to ''
+
+                    url = url.replace(/\\/g, '\/'); // replace backslashes
+                    // console.log('Replace', url, pathVars[i], env[pathKey]);
+                }
+            }
+            return url;
+        }
+    }
+}

--- a/lib/toolbar/statusIcon.js
+++ b/lib/toolbar/statusIcon.js
@@ -49,7 +49,7 @@ function prepareButton(iconState) {
 }
 
 
-function handleClick(state) {
+function handleClick(/* state */) {
     open({ id: self.id });
 }
 

--- a/lib/toolbar/statusIcon.js
+++ b/lib/toolbar/statusIcon.js
@@ -1,9 +1,9 @@
-var self = require("sdk/self");
+var self = require('sdk/self');
 var buttons = require('sdk/ui/button/action');
-var { open } = require("sdk/preferences/utils");
-var _ = require("sdk/l10n").get;
+var {open} = require('sdk/preferences/utils');
+var _ = require('sdk/l10n').get;
 
-/**
+/*
  * Create toolbar icon
  * @param initial icon state
  * @return {changeState: function(state) {...}} change state method
@@ -13,10 +13,10 @@ function create(iconState) {
     var curState = prepareButton(iconState);
 
     var button = buttons.ActionButton({
-      id: "local-link-addon",
-      label: curState.label,
-      icon: curState.icon,
-      onClick: handleClick
+        id: 'local-link-addon',
+        label: curState.label,
+        icon: curState.icon,
+        onClick: handleClick
     });
 
     var statusIcon = {
@@ -31,26 +31,26 @@ function create(iconState) {
     return statusIcon;
 }
 
-/**
- * Helper function for easier toggling between active / inactive icon
- */
+/*
+* Helper function for easier toggling between active / inactive icon
+*/
 function prepareButton(iconState) {
-    var filePrefix = iconState ? 'active': 'inactive',
+    var filePrefix = iconState ? 'active' : 'inactive',
         filePrefixLocale = _('LABEL_ADDONBAR_HOVER_STATE_' + filePrefix);
 
     return {
         label: _('LABEL_ADDONBAR_ICON_HOVER', filePrefixLocale),
         icon: {
-          "16": "./img/" + filePrefix + "_icon_16.png",
-          "32": "./img/" + filePrefix + "_icon_32.png",
-          "64": "./img/" + filePrefix + "_icon_64.png"
+            '16': './img/' + filePrefix + '_icon_16.png',
+            '32': './img/' + filePrefix + '_icon_32.png',
+            '64': './img/' + filePrefix + '_icon_64.png'
         }
     };
 }
 
 
 function handleClick(/* state */) {
-    open({ id: self.id });
+    open({id: self.id});
 }
 
 exports.create = create;

--- a/lib/utils/link-util.js
+++ b/lib/utils/link-util.js
@@ -2,10 +2,10 @@
  * License: www.mozilla.org/MPL/
  * Created by https://github.com/feinstaub/firefox_addon_local_filesystem_links
  */
-"use strict";
+'use strict';
 
-const osUtil = require( "./os-util" );
-const stringUtil = require( "./string-util" );
+const osUtil = require('./os-util');
+const stringUtil = require('./string-util');
 
 //
 // Used for Windows OS:
@@ -16,28 +16,29 @@ const stringUtil = require( "./string-util" );
 // added regex so double slash can be used instead of triple
 // and 4 slashes are possible for network path
 
-var fixFileLinkStringForWindowsOs = function( link ) {
+var fixFileLinkStringForWindowsOs = function(link) {
     var regex = /file:(\/\/){2}/;
 
-    if ( link.match( regex ) ) {
+    if (link.match(regex)) {
 
         // Four slashes ////network/test
-        link = link.replace( regex, "//" );
+        link = link.replace(regex, '//');
     } else {
-        // console.log( "two or three slashes", link );
-        link = link.replace( /file:(\/){2,3}/, "" ); // Two or three slashes
+        // console.log( 'two or three slashes', link );
+        link = link.replace(/file:(\/){2,3}/, ''); // Two or three slashes
         // console.log( "replaced", link );
     }
 
     // http://www.w3schools.com/jsref/jsref_replace.asp
-    link = link.replace( /\//g, "\\" ); // Globally find / and replace with \
-    // console.log( "fixed win", link );
+    link = link.replace(/\//g, '\\'); // Globally find / and replace with \
+    // console.log( 'fixed win', link );
     return link;
 };
+
 exports.fixFileLinkStringForWindowsOs = fixFileLinkStringForWindowsOs;
 
 // TODO: write unit test
-var fixFileLinkStringForLinuxOs = function( link ) {
+var fixFileLinkStringForLinuxOs = function(link) {
     //console.log('fix linux file link (input)', link);
     /* feinstaub's code
     link = link.replace( "file://", "" ); // file:///home/user --> /home/user
@@ -56,53 +57,53 @@ var fixFileLinkStringForLinuxOs = function( link ) {
 
     var regex = /file:(\/\/){2}/;
 
-    if ( link.match( regex ) ) {
+    if (link.match(regex)) {
 
         // Four slashes ////network/test
-        link = link.replace( regex, "//" );
+        link = link.replace(regex, '//');
     } else {
-        // console.log( "two or three slashes", link ); // e.g. file:///path or file://path
-        link = link.replace( /file:\//, "" );        // Two or three slashes --> keep one or two slashes
-        // console.log( "replaced", link ); // --> /path or //path
+        // console.log( 'two or three slashes', link ); // e.g. file:///path or file://path
+        link = link.replace(/file:\//, '');        // Two or three slashes --> keep one or two slashes
+        // console.log( 'replaced', link ); // --> /path or //path
     }
 
     // same hack to remove / before ~
 
-    link = link.replace(/(\/){1,2}~/, "~"); // one or two slashes before ~
+    link = link.replace(/(\/){1,2}~/, '~'); // one or two slashes before ~
 
     // http://www.w3schools.com/jsref/jsref_replace.asp
-    //link = link.replace( /\//g, "/" ); // Globally find / and replace with \ --> not needed in linux forward slashes are OK
-    // console.log( "fixed linux", link );
+    //link = link.replace( /\//g, '/' ); // Globally find / and replace with \ --> not needed in linux forward slashes are OK
+    // console.log( 'fixed linux', link );
     return link;
 };
 
-exports.osSpecificLinkStringFix = function( link ) {
-    if ( osUtil.isWindowsOs() ) {
-        return fixFileLinkStringForWindowsOs( link );
+exports.osSpecificLinkStringFix = function(link) {
+    if (osUtil.isWindowsOs()) {
+        return fixFileLinkStringForWindowsOs(link);
     } else {
-        return fixFileLinkStringForLinuxOs( link );
+        return fixFileLinkStringForLinuxOs(link);
     }
 };
 
 //
-// "aaa" --> "aaa"
+// 'aaa' --> "aaa"
 // "\"bbb\"" --> "bbb"
 //
-var stripQuotes = function( localPathWithOrWithoutQuotes ) {
-    let trimmed = stringUtil.strTrim( localPathWithOrWithoutQuotes );
-    if ( stringUtil.strStartsWith( trimmed, "\"" ) ) {
-        return trimmed.replace( /^\"(.*)\"$/, "$1" );
+var stripQuotes = function(localPathWithOrWithoutQuotes) {
+    let trimmed = stringUtil.strTrim(localPathWithOrWithoutQuotes);
+
+    if (stringUtil.strStartsWith(trimmed, '\"')) {
+        return trimmed.replace(/^\"(.*)\"$/, '$1');
     } else {
         return trimmed;
     }
 };
+
 exports.stripQuotes = stripQuotes;
 
-exports.looksLikeLocalFileLink = function( text ) {
-    if ( text !== undefined && stringUtil.strStartsWith( text, "file:///" ) ) {
-
+exports.looksLikeLocalFileLink = function(text) {
+    if (text !== undefined && stringUtil.strStartsWith(text, 'file:///')) {
         // TODO: e. g. the first part must only be one letter (the drive letter and a colon)
-
         return true;
     }
 

--- a/lib/utils/matchUrl.js
+++ b/lib/utils/matchUrl.js
@@ -1,24 +1,24 @@
-"use strict";
+'use strict';
 
-var { MatchPattern } = require( "sdk/util/match-pattern" );
+var {MatchPattern} = require('sdk/util/match-pattern');
 
-/**
+/*
  * Check if URI is in whitelist
- * @param includePatterns object {0: "*", ...}
+ * @param includePatterns object {0: '*', ...}
  * @param uri to test
  * @return testResult true or false
  */
-exports.isUriIncluded = function( includePatterns, uri ) {
-    
-    return Object.keys( includePatterns ).some(function ( key ) {
+exports.isUriIncluded = function(includePatterns, uri) {
+
+    return Object.keys(includePatterns).some(function(key) {
         // console.log(includePatterns[key]);
         // @todo includePatterns[key] can throw an error if user passes a whitespace
         //       in front of *.url and it fails silently at the moment.
-        var pattern = new MatchPattern( includePatterns[ key ] );
+        var pattern = new MatchPattern(includePatterns[ key ]);
 
         // use val
         // console.log('pattern = ' + includePatterns[key]);
-        return ( pattern.test( uri ) );
+        return pattern.test(uri);
     });
     //}
-}
+};

--- a/lib/utils/os-util.js
+++ b/lib/utils/os-util.js
@@ -22,6 +22,7 @@ var retrieveIsWindowsOs = function() {
 const constIsWindowsOs = retrieveIsWindowsOs();
 
 var isWindowsOs = function() {
+    // console.log('isWindowsOs', constIsWindowsOs);
     return constIsWindowsOs;
 };
 exports.isWindowsOs = isWindowsOs;

--- a/lib/utils/os-util.js
+++ b/lib/utils/os-util.js
@@ -2,14 +2,15 @@
  * License: www.mozilla.org/MPL/
  * Created by https://github.com/feinstaub/firefox_addon_local_filesystem_links
  */
-"use strict";
+'use strict';
 
-var { Cc, Ci } = require( "chrome" );
+var {Cc, Ci} = require('chrome');
 
 var getOsStringTag = function() {
 
     // https://developer.mozilla.org/en/nsIXULRuntime
-    var xulRuntime = Cc[ "@mozilla.org/xre/app-info;1" ].getService( Ci.nsIXULRuntime );
+    var xulRuntime = Cc['@mozilla.org/xre/app-info;1'].
+        getService(Ci.nsIXULRuntime);
 
     // see https://developer.mozilla.org/en/OS_TARGET
     return xulRuntime.OS;
@@ -17,7 +18,8 @@ var getOsStringTag = function() {
 
 var retrieveIsWindowsOs = function() {
     var osStringTag = getOsStringTag();
-    return osStringTag === "WINNT";
+
+    return osStringTag === 'WINNT';
 };
 const constIsWindowsOs = retrieveIsWindowsOs();
 
@@ -25,12 +27,13 @@ var isWindowsOs = function() {
     // console.log('isWindowsOs', constIsWindowsOs);
     return constIsWindowsOs;
 };
+
 exports.isWindowsOs = isWindowsOs;
 
 exports.getFileManagerDisplayName = function() {
-    if ( isWindowsOs() ) {
-        return "Windows Explorer";
+    if (isWindowsOs()) {
+        return 'Windows Explorer';
     } else {
-        return "default file manager";
+        return 'default file manager';
     }
 };

--- a/lib/utils/string-util.js
+++ b/lib/utils/string-util.js
@@ -2,29 +2,34 @@
  * License: www.mozilla.org/MPL/
  * Created by https://github.com/feinstaub/firefox_addon_local_filesystem_links
  */
-"use strict";
+'use strict';
 
 //
 // Helper methods
 //
 
-var strTrim = function( str ) {
-    let trimmed = str.replace( /^\s+|\s+$/g, "" );
+var strTrim = function(str) {
+    let trimmed = str.replace(/^\s+|\s+$/g, '');
+
     return trimmed;
 };
+
 exports.strTrim = strTrim;
 
-var strStartsWith = function( str, prefix ) {
-    return str.substring( 0, prefix.length ) === prefix;
+var strStartsWith = function(str, prefix) {
+    return str.substring(0, prefix.length) === prefix;
 };
+
 exports.strStartsWith = strStartsWith;
 
-var strEndsWith = function( str, suffix ) {
-    return str.indexOf( suffix, str.length - suffix.length ) !== -1;
+var strEndsWith = function(str, suffix) {
+    return str.indexOf(suffix, str.length - suffix.length) !== -1;
 };
+
 exports.strEndsWith = strEndsWith;
 
-var strContains = function( str, substr ) {
-    return str.indexOf( substr ) !== -1;
+var strContains = function(str, substr) {
+    return str.indexOf(substr) !== -1;
 };
+
 exports.strContainsWith = strContains;

--- a/package.json
+++ b/package.json
@@ -1,24 +1,25 @@
 {
-    "title": "Local Filesystem Links",
-    "name": "alien-local-filesystem-links",
-    "version": "0.99.42",
-    "description": "Scans pages for file:/// links and makes it possible to open them with the system's file browser.",
-    "main": "index.js",
-    "author": "austrALIENsun",
-    "scripts": {
-      "jpm": "jpm run",
-      "jpmLinux": "jpm run -b $(which firefox)"
-    },
-    "engines": {
-        "firefox": ">=38.0a1",
-        "fennec": ">=38.0a1"
-    },
-    "license": "MPL 1.1/GPL 3.0",
-    "id": "jid1-JAzC7z53jemo5Q@jetpack",
-    "permissions": {
-        "multiprocess": true
-    },
-    "preferences": [{
+  "title": "Local Filesystem Links",
+  "name": "alien-local-filesystem-links",
+  "version": "0.99.42",
+  "description": "Scans pages for file:/// links and makes it possible to open them with the system's file browser.",
+  "main": "index.js",
+  "author": "austrALIENsun",
+  "scripts": {
+    "jpm": "jpm run",
+    "jpmLinux": "jpm run -b $(which firefox)"
+  },
+  "engines": {
+    "firefox": ">=38.0a1",
+    "fennec": ">=38.0a1"
+  },
+  "license": "MPL 1.1/GPL 3.0",
+  "id": "jid1-JAzC7z53jemo5Q@jetpack",
+  "permissions": {
+    "multiprocess": true
+  },
+  "preferences": [
+    {
       "name": "whitelist",
       "title": "Urls added to white-list will be clickable",
       "description": "Any link that will be added to the white-list will be clickable. Empty or * will enable all. Multiple urls are space separated. Wildcards are allowed e.g. *.trello.com",
@@ -46,15 +47,23 @@
       "description": "Changes the default click behaviour of file-links. Default = direct file link open.",
       "value": "O",
       "options": [
-          {
-              "value": "O",
-              "label": "Open"
-          },
-          {
-              "value": "R",
-              "label": "Reveal"
-          }
+        {
+          "value": "O",
+          "label": "Open"
+        },
+        {
+          "value": "R",
+          "label": "Reveal"
+        }
       ]
     }
-]
+  ],
+  "devDependencies": {
+    "babel-eslint": "^6.1.2",
+    "eslint": "^3.1.0",
+    "eslint-config-defaults": "^9.0.0",
+    "gulp": "^3.9.1",
+    "gulp-eslint": "^3.0.1",
+    "gulp-watch": "^4.3.8"
+  }
 }

--- a/test/webserver/index.htm
+++ b/test/webserver/index.htm
@@ -29,5 +29,8 @@ it does not if the page is served by a webserver; thats what the add-on is for).
 
 <p><a href="issue16/index.html">Issue 16 - security improvement</a>
     (<a href="https://github.com/feinstaub/firefox_addon_local_filesystem_links/issues/16">Issue 16</a>)</p>
+
+<p><a href="issue22/index.html">Issue 22 - Windows / Linux env. path varibales</a>
+    (<a href="https://github.com/feinstaub/firefox_addon_local_filesystem_links/issues/22">Issue 22</a>)</p>
 </body>
 </html>

--- a/test/webserver/issue22/index.html
+++ b/test/webserver/issue22/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Issue 22 - Windows / Linux path variables</title>
+    </head>
+    <body>
+        <h1>Test if we can open links with environment path variables e.g. %HOMEPATH%</h1>
+        <p>Why are three slashes required file:///%HOMEDRIVE%? With only two it will be relpace to file:///</p>
+        <p>Probably FF will remove %HOMEDRIVE% because it is not a valid uri.</p>
+        <h2>Info to env. var</h2>
+        <p>Windows list all env. variables with <strong>SET</strong> command.</p>
+        <p>Linux list all env. variables with <strong>printenv</strong> command.</p>
+        Windows setting: SET name=c:\<br/>
+        Linux setting: export name=/tmp<br/>
+        <h2>Windows</h2>
+        <ul>
+            <li><a href="file:///%HOMEDRIVE%%HOMEPATH%/">%HOMEPATH%/</a></li>
+            <li><a href="file://%HOMEDRIVE%%HOMEPATH%/">%HOMEPATH% with only two slashes file:// (not working)/</a></li>
+            <li><a href="file:///%LOCALAPPDATA%/">%LOCALAPPDATA%/</a></li>
+            <li><a href="file:///%LOCALAPPDATA%/blank in path/test.txt">%LOCALAPPDATA% with blanks in path C:\Users\%USERNAME%\AppData\Local\blank in path\test.txt/</a></li>
+        </ul>
+        <h2>Linux</h2>
+        <ul>
+            <li><a href="file:///$HOME$/">$HOME$/</a></li>
+            <li><a href="file:///$HOME$/path with space">$HOME$/path with space</a></li>
+            <li><a href="file:///$TMPDIR$/">$TMPDIR$ set with export TMPDIR="/tmp"</a></li>
+            <li><a href="file:///$TMPDIR$/$TEST$/test.txt">$TMPDIR$ $TEST set with export TEST="test" (combined $TMPDIR$TEST/test.txt)</a></li>
+        </ul>
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
@feinstaub Please have a look at this branch for the style issues that you've mentioned in the last PR.

I've added eslint with gulp so checking style is easy. Just `npm install` everything and start `gulp` to watch the project for changes or directly lint with `gulp lint`.

Is the style OK? It's the Google Javascript style and not the Crockford style because I couldn't find a config for it.
I'm not sure if we should use 2 space indentation like in Google style. Because I would personally prefer to use 4 spaces. It's in my opinion more readable. Should I change it back to 4 spaces and modify that linting rule, what do you think?

It took me a while to fix all linting errors. I started with over 100 errors with-out indentation errors.

Most errors were `space-in-parens` and some `unused-vars`.

The following points are modified for the repo (see .eslintrc file):
- "no-console": "off" --> allow console.logs
- "no-invalid-this": 0 --> allow `this` usage, used inside content-script (could probably be rewritten)
- "new-cap": [0, {newIsCap: false}] --> SDK function PageMod used newCap. So we can't use new-cap.
- "globals": { "jQuery": true } --> jQuery is the only global

One point that I'm not sure, do I have to add `.eslintrc` and `gulpfile.js` to the `.jpmignore` file? I think it should be added because JPM doesn't need these files in the XPI package.