### PR TITLE
Fix issue 84

### DIFF
--- a/data/js/fileLinkAddonContent.js
+++ b/data/js/fileLinkAddonContent.js
@@ -81,12 +81,13 @@
     // Use delegate so the click event is also avaliable at newly added links
     $(document).on('click', fileLinkSelectors.join(', '), function(e) {
         e.preventDefault(); // prevent default to avoid browser to launch smb://
-        // console.log( "clicked file link: " + this.href, options.revealOpenOption);
-
+        // console.log( "clicked file link: " + decodeURIComponent(this.href), options.revealOpenOption);
         self.postMessage({
             action: 'open',
             // removed decodeURIComponent because env. var. failed
-            url: this.href, //decodeURIComponent(this.href),
+            // --> encoding required for special chars like accents - implement env. var differently
+            // url: this.href, //decodeURIComponent(this.href),
+            url: decodeURIComponent(this.href),
             reveal: options.revealOpenOption == 'O' ? false : true
         });
     });
@@ -98,13 +99,12 @@
         var link = $(e.currentTarget).data('link');
 
         e.preventDefault();
-
         // console.log('clicked icon', link, options.revealOpenOption);
 
         self.postMessage({
             action: 'open',
             // removed decodeURIComponent because env. var. failed
-            url: link, //decodeURIComponent(link),
+            url: decodeURIComponent(link),
             reveal: options.revealOpenOption == 'O' ? true : false,
             backslashReplaceRequired: true
         });

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function onAttach(worker) {
     if (!attachedCM) {
         // Add context menu (only if include matches, that's why requiring here)
         require('./lib/contextMenu')(function(path, reveal) { // Callback
+            // console.log('launcher start - context menu', path);
             launcher.start(path, reveal);
         });
 
@@ -67,6 +68,7 @@ function onAttach(worker) {
             // later add a option to enable env. paths vars?
             // console.log('checklink', actionObj);
             var replacedLink = curSysEnv.checkLink(actionObj.url);
+            // var replacedLink = actionObj.url;
 
             launcher.start(replacedLink, actionObj.reveal);
             break;

--- a/lib/launch-local-process.js
+++ b/lib/launch-local-process.js
@@ -55,6 +55,7 @@ function url2path(url) {
                 // console.log('unix test', isWindowsOs())
                 if (!isWindowsOs()) { // decent OS
                     var unixPath = uri.path;
+
                     // replace backslashes (just if there are any)
                     // windows can open file:\\ but Linux can't
                     // console.log('test unixPath', /\%5C/.test(unixPath),

--- a/test/webserver/index.htm
+++ b/test/webserver/index.htm
@@ -34,5 +34,8 @@ it does not if the page is served by a webserver; thats what the add-on is for).
 
 <p><a href="issue22/index.html">Issue 22 - Windows / Linux env. path varibales</a>
     (<a href="https://github.com/feinstaub/firefox_addon_local_filesystem_links/issues/22">Issue 22</a>)</p>
+
+<p><a href="issue84/index.html">Issue 84 - european accents</a>
+    (<a href="https://github.com/feinstaub/firefox_addon_local_filesystem_links/issues/84">Issue 84</a>)</p>
 </body>
 </html>

--- a/test/webserver/issue22/index.html
+++ b/test/webserver/issue22/index.html
@@ -13,7 +13,29 @@
         <p>Linux list all env. variables with <strong>printenv</strong> command.</p>
         Windows setting: SET name=c:\<br/>
         Linux setting: export name=/tmp<br/>
+
+        <p>Encoding issue: % in uri is a problem - interference with decodeUriComponent that is required for accents in urls. <br/>
+            with-out decodeUriComponent the links are working as commented below. <br/>
+            Temporary work-around manually encoding in links with env. vars required %25 for % for windows and %24 for $ in Linux
+        </p>
         <h2>Windows</h2>
+        <ul>
+            <li><a href="file:///%25HOMEDRIVE%25%25HOMEPATH%25/">%HOMEPATH%/</a></li>
+            <li><a href="file://%25HOMEDRIVE%%HOMEPATH%25/">%HOMEPATH% with only two slashes file:// (not working)/</a></li>
+            <li><a href="file:///%25LOCALAPPDATA%25/">%LOCALAPPDATA%/</a></li>
+            <li><a href="file:///%25LOCALAPPDATA%25/blank in path/test.txt">%LOCALAPPDATA% with blanks in path C:\Users\%USERNAME%\AppData\Local\blank in path\test.txt/</a></li>
+        </ul>
+        <h2>Linux</h2>
+        <ul>
+            <li><a href="file:///%24HOME%24/">$HOME$/</a></li>
+            <li><a href="file:///%24HOME%24/path with space">$HOME$/path with space</a></li>
+            <li><a href="file:///%24TMPDIR%24/">$TMPDIR$ set with export TMPDIR="/tmp"</a></li>
+            <li><a href="file:///%24TMPDIR%24/%24TEST%24/test.txt">$TMPDIR$ $TEST set with export TEST="test" (combined $TMPDIR$TEST/test.txt)</a></li>
+        </ul>
+        <!--
+            the following would be better but couldn't find a way to implement it
+        -->
+        <!--<h2>Windows</h2>
         <ul>
             <li><a href="file:///%HOMEDRIVE%%HOMEPATH%/">%HOMEPATH%/</a></li>
             <li><a href="file://%HOMEDRIVE%%HOMEPATH%/">%HOMEPATH% with only two slashes file:// (not working)/</a></li>
@@ -26,7 +48,7 @@
             <li><a href="file:///$HOME$/path with space">$HOME$/path with space</a></li>
             <li><a href="file:///$TMPDIR$/">$TMPDIR$ set with export TMPDIR="/tmp"</a></li>
             <li><a href="file:///$TMPDIR$/$TEST$/test.txt">$TMPDIR$ $TEST set with export TEST="test" (combined $TMPDIR$TEST/test.txt)</a></li>
-        </ul>
+        </ul>-->
         </p>
     </body>
 </html>

--- a/test/webserver/issue84/index.html
+++ b/test/webserver/issue84/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Issue 84 - European accents</title>
+    </head>
+    <body>
+        <h1>In version 0.99.46 - European accents can't be opened!</h1>
+        <p>decodeURIComponent is important for direct link click to make these characters work
+        - side effect env. var not working with it (work-around needed for env. var)</p>
+        <a href="file://c:/tmp/áéíóú.txt">c:/tmp/áéíóú.txt</a><br/>
+        <a href="file://c:/tmp/áéíóú/áéíóú.txt">c:/tmp/áéíóú/áéíóú.txt</a></li>
+    </body>
+</html>

--- a/test/webserver/issue84/index.html
+++ b/test/webserver/issue84/index.html
@@ -8,7 +8,11 @@
         <h1>In version 0.99.46 - European accents can't be opened!</h1>
         <p>decodeURIComponent is important for direct link click to make these characters work
         - side effect env. var not working with it (work-around needed for env. var)</p>
+        <h2>Windows</h2>
         <a href="file://c:/tmp/áéíóú.txt">c:/tmp/áéíóú.txt</a><br/>
-        <a href="file://c:/tmp/áéíóú/áéíóú.txt">c:/tmp/áéíóú/áéíóú.txt</a></li>
+        <a href="file://c:/tmp/áéíóú/áéíóú.txt">c:/tmp/áéíóú/áéíóú.txt</a><br/>
+        <h2>Linux</h2>
+        <a href="file:///~/tmp/áéíóú.txt">/~/tmp/áéíóú.txt</a><br/>
+        <a href="file:///~/tmp/áéíóú/áéíóú.txt">/~/tmp/áéíóú/áéíóú.txt</a><br/>
     </body>
 </html>


### PR DESCRIPTION
@feinstaub There is a smaller bug. Please have a look if this fix is OK.

There is a drawback with my solution - environment variables are only possible if the user enters them as %25 for % (Windows) and %24 for $ (Linux).

But I think that's OK because this is probably a rarely used feature.
Maybe I'm finding a better solution for this later. The problem is that the link isn't working with `decodeUriComponent`. But with-out decode the accented uri won't work.
What do you think? Is that OK? You can see the usage in the test-cases for issue-22 at the test server.